### PR TITLE
Fix max-heap comment

### DIFF
--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -63,7 +63,7 @@ function heap_sort_inplace!(xs, xis)
     end
 end
 
-# Binary min-heap percolate down.
+# Binary max-heap percolate down.
 function percolate_down!(xs::AbstractArray,
                          xis::AbstractArray,
                          dist::Number,


### PR DESCRIPTION
Very minor fix to a very confusing comment :-)  `xs[1]` is the maximum element, so this is a max heap, right?  Same comment occurs in KDTrees.jl which is where I noted and got confused about it first.