### PR TITLE
Replace deprecated testloop with testset macro

### DIFF
--- a/test/test_inrange.jl
+++ b/test/test_inrange.jl
@@ -1,7 +1,7 @@
 # Does not test leafsize
 @testset "inrange" begin
-    @testloop "metric" for metric in [Euclidean()]
-        @testloop "tree type" for TreeType in trees_with_brute
+    @testset "metric" for metric in [Euclidean()]
+        @testset "tree type" for TreeType in trees_with_brute
             data = [0.0 0.0 0.0 0.0 1.0 1.0 1.0 1.0;
                     0.0 0.0 1.0 1.0 0.0 0.0 1.0 1.0;
                     0.0 1.0 0.0 1.0 0.0 1.0 0.0 1.0] # 8 node cube

--- a/test/test_knn.jl
+++ b/test/test_knn.jl
@@ -3,8 +3,8 @@
 import Distances.evaluate
 
 @testset "knn" begin
-    @testloop "metric" for metric in metrics
-        @testloop "tree type" for TreeType in trees_with_brute
+    @testset "metric" for metric in metrics
+        @testset "tree type" for TreeType in trees_with_brute
             # 8 node rectangle
             data = [0.0 0.0 0.0 0.5 0.5 1.0 1.0 1.0;
                     0.0 0.5 1.0 0.0 1.0 0.0 0.5 1.0]

--- a/test/test_monkey.jl
+++ b/test/test_monkey.jl
@@ -3,8 +3,8 @@ import NearestNeighbors.MinkowskiMetric
 # some edge case has been missed in the real tests
 
 
-@testloop "metric" for metric in fullmetrics
-    @testloop "tree type" for TreeType in trees_with_brute
+@testset "metric" for metric in fullmetrics
+    @testset "tree type" for TreeType in trees_with_brute
         @testset "knn monkey" begin
             # Checks that we find existing point in the tree
             # and that it is the closest


### PR DESCRIPTION
Should fix build errors with latest BaseTestNext. See https://github.com/JuliaLang/julia/pull/14148