### PR TITLE
WIP: Allow more types in the tree data

### DIFF
--- a/src/NearestNeighbors.jl
+++ b/src/NearestNeighbors.jl
@@ -22,7 +22,7 @@ export Euclidean,
 # Change this to enable debugging
 const DEBUG = false
 
-abstract NNTree{T <: AbstractFloat, P <: Metric}
+abstract NNTree{T <: Real, P <: Metric}
 
 function check_input(tree::NNTree, points::AbstractArray)
     ndim_points = size(points,1)

--- a/src/brute_tree.jl
+++ b/src/brute_tree.jl
@@ -1,4 +1,4 @@
-immutable BruteTree{T <: AbstractFloat, M <: Metric} <: NNTree{T, M}
+immutable BruteTree{T <: Real, M <: Metric} <: NNTree{T, M}
     data::Matrix{T}
     metric::M
     leafsize::Int
@@ -10,24 +10,25 @@ end
 
 Creates a `BruteTree` from the data using the given `metric`.
 """
-function BruteTree{T <: AbstractFloat}(data::Matrix{T}, metric::Metric=Euclidean();
+function BruteTree{T <: Real}(data::Matrix{T}, metric::Metric=Euclidean();
                               reorder::Bool=false, leafsize=0, storedata::Bool=true)
     BruteTree(storedata ? data : similar(data,0,0), metric, 0, reorder)
 end
 
-function _knn{T}(tree::BruteTree{T},
-                 point::AbstractVector{T},
-                 k::Int)
+function _knn{T, P}(tree::BruteTree{T},
+                    point::AbstractVector{P},
+                    k::Int)
+    Tret = Distances.result_type(tree.metric, tree.data, point)
     best_idxs = [-1 for _ in 1:k]
-    best_dists = [typemax(T) for _ in 1:k]
+    best_dists = [typemax(Tret) for _ in 1:k]
     knn_kernel!(tree, point, best_idxs, best_dists)
     return best_idxs, best_dists
 end
 
-function knn_kernel!{T}(tree::BruteTree{T},
-                        point::AbstractArray{T},
-                        best_idxs::Vector{Int},
-                        best_dists::Vector{T})
+function knn_kernel!{T, Tret, P}(tree::BruteTree{T},
+                                 point::AbstractArray{P},
+                                 best_idxs::Vector{Int},
+                                 best_dists::Vector{Tret})
 
     for i in 1:size(tree.data, 2)
         @POINT 1
@@ -40,8 +41,8 @@ function knn_kernel!{T}(tree::BruteTree{T},
     end
 end
 
-function _inrange{T}(tree::BruteTree{T},
-                     point::AbstractVector{T},
+function _inrange{T, P}(tree::BruteTree{T},
+                     point::AbstractVector{P},
                      radius::Number)
     idx_in_ball = Int[]
     inrange_kernel!(tree, point, radius, idx_in_ball)
@@ -49,8 +50,8 @@ function _inrange{T}(tree::BruteTree{T},
 end
 
 
-function inrange_kernel!{T}(tree::BruteTree{T},
-                            point::Vector{T},
+function inrange_kernel!{T, P}(tree::BruteTree{T},
+                            point::Vector{P},
                             r::Number,
                             idx_in_ball::Vector{Int})
     for i in 1:size(tree.data, 2)

--- a/src/hyperrectangles.jl
+++ b/src/hyperrectangles.jl
@@ -1,4 +1,4 @@
-immutable HyperRectangle{T <: AbstractFloat}
+immutable HyperRectangle{T <: Real}
     mins::Vector{T}
     maxes::Vector{T}
 end
@@ -27,9 +27,9 @@ end
 
 # Splits a hyper rectangle into two rectangles by dividing the
 # rectangle at a specific value in a given dimension.
-function split{T <: AbstractFloat}(hyper_rec::HyperRectangle{T},
-                                   dim::Int,
-                                   value::T)
+function split{T, P}(hyper_rec::HyperRectangle{T},
+                  dim::Int,
+                  value::P)
     new_max = copy(hyper_rec.maxes)
     new_max[dim] = value
 
@@ -40,7 +40,7 @@ function split{T <: AbstractFloat}(hyper_rec::HyperRectangle{T},
            HyperRectangle(new_min, hyper_rec.maxes)
 end
 
-function find_maxspread{T <: AbstractFloat}(hyper_rec::HyperRectangle{T})
+function find_maxspread{T}(hyper_rec::HyperRectangle{T})
     # Find the dimension where we have the largest spread.
 
     split_dim = 1
@@ -59,18 +59,18 @@ end
 ############################################
 # Rectangle - Point functions
 ############################################
-@inline function get_min_dim{T <: AbstractFloat}(rec::HyperRectangle{T}, point::Vector{T}, dim::Int)
+@inline function get_min_dim{T, P}(rec::HyperRectangle{T}, point::Vector{P}, dim::Int)
     @inbounds d = abs2(max(0, max(rec.mins[dim] - point[dim], point[dim] - rec.maxes[dim])))
     d
 end
 
-@inline function get_max_dim{T <: AbstractFloat}(rec::HyperRectangle{T}, point::Vector{T}, dim::Int)
+@inline function get_max_dim{T, P}(rec::HyperRectangle{T}, point::Vector{P}, dim::Int)
     @inbounds d = abs2(max(rec.maxes[dim] - point[dim], point[dim] - rec.mins[dim]))
     d
 end
 
 # Max distance between rectangle and point
-@inline function get_max_distance{T <: AbstractFloat}(rec::HyperRectangle{T}, point::Vector{T})
+@inline function get_max_distance{T, P}(rec::HyperRectangle{T}, point::Vector{P})
     max_dist = zero(T)
     @inbounds @simd for dim in eachindex(point)
         max_dist += abs2(max(rec.maxes[dim] - point[dim], point[dim] - rec.mins[dim]))
@@ -79,7 +79,7 @@ end
 end
 
 # Min distance between rectangle and point
-@inline function get_min_distance{T <: AbstractFloat}(rec::HyperRectangle{T}, point::Vector{T})
+@inline function get_min_distance{T, P}(rec::HyperRectangle{T}, point::Vector{P})
     min_dist = zero(T)
     @inbounds @simd for dim in eachindex(point)
         min_dist += abs2(max(0, max(rec.mins[dim] - point[dim], point[dim] - rec.maxes[dim])))
@@ -88,14 +88,14 @@ end
 end
 
 # (Min, Max) distance between rectangle and point
-@inline function get_min_max_distance{T <: AbstractFloat}(rec::HyperRectangle{T}, point::Vector{T})
+@inline function get_min_max_distance{T, P}(rec::HyperRectangle{T}, point::Vector{P})
     min_dist = get_min_distance(rec, point)
     max_dist = get_max_distance(rec, point)
     return min_dist, max_dist
 end
 
 # (Min, Max) distance between rectangle and point for a certain dim
-@inline function get_min_max_dim{T <: AbstractFloat}(rec::HyperRectangle{T}, point::Vector{T}, dim::Int)
+@inline function get_min_max_dim{T, P}(rec::HyperRectangle{T}, point::Vector{P}, dim::Int)
     min_dist_dim = get_min_dim(rec, point, dim)
     max_dist_dim = get_max_dim(rec, point, dim)
     return min_dist_dim, max_dist_dim

--- a/src/inrange.jl
+++ b/src/inrange.jl
@@ -4,10 +4,10 @@
 Find all the points in the tree which is closer than `radius` to `points`. If
 `sortres = true` the resulting indices are sorted.
 """
-function inrange{T <: AbstractFloat}(tree::NNTree{T},
-                                     points::AbstractArray{T},
-                                     radius::Number,
-                                     sortres=false)
+function inrange{T <: Real, P <: Real}(tree::NNTree{T},
+                                       points::AbstractArray{P},
+                                       radius::Number,
+                                       sortres::Bool=false)
     check_input(tree, points)
 
     if radius < 0
@@ -15,7 +15,7 @@ function inrange{T <: AbstractFloat}(tree::NNTree{T},
     end
 
     idxs = Array(Vector{Int}, size(points, 2))
-    point = zeros(T, size(points, 1))
+    point = zeros(P, size(points, 1))
 
     for i in 1:size(points, 2)
         @devec point[:] = points[:, i]
@@ -35,10 +35,3 @@ end
 
 do_return_inrange(idxs, ::AbstractVector) = idxs[1]
 do_return_inrange(idxs, ::AbstractMatrix) = idxs
-
-function inrange{T <: AbstractFloat, P <: Real}(tree::NNTree{T},
-                                                points::AbstractArray{P},
-                                                radius::Number,
-                                                sortres=false)
-    inrange(tree, map(T, points), radius, sortres)
-end

--- a/src/knn.jl
+++ b/src/knn.jl
@@ -5,8 +5,8 @@ Performs a lookup of the `k` nearest neigbours to the `points` from the data
 in the `tree`. If `sortres = true` the result is sorted such that the results are
 in the order of increasing distance to the point.
 """
-function knn{T <: AbstractFloat}(tree::NNTree{T}, points::AbstractArray{T}, k::Int, sortres=false)
-
+function knn{T <: Real, P <: Real}(tree::NNTree{T}, points::AbstractArray{P}, k::Int, sortres::Bool=false)
+    Tret = Distances.result_type(tree.metric, tree.data, points)
     check_input(tree, points)
     n_points = size(points, 2)
     n_dim = size(points, 1)
@@ -15,9 +15,9 @@ function knn{T <: AbstractFloat}(tree::NNTree{T}, points::AbstractArray{T}, k::I
         throw(ArgumentError("k > number of points in tree or ≦ 0"))
     end
 
-    dists = Array(Vector{T}, n_points)
-    idxs = Array(Vector{Int}, n_points)
-    point = zeros(T, n_dim)
+    dists = Vector{Vector{Tret}}(n_points)
+    idxs = Vector{Vector{Int}}(n_points)
+    point = zeros(P, n_dim)
     for i in 1:n_points
         @devec point[:] = points[:, i]
         best_idxs, best_dists = _knn(tree, point, k)
@@ -37,8 +37,3 @@ end
 
 do_return(idxs, dists, ::AbstractVector) = idxs[1], dists[1]
 do_return(idxs, dists, ::AbstractMatrix) = idxs, dists
-
-# Conversions for knn if input data is not floating points
-function knn{T <: AbstractFloat, P <: Real}(tree::NNTree{T}, points::AbstractArray{P}, k::Int)
-  knn(tree, map(T, points), k)
-end

--- a/src/tree_ops.jl
+++ b/src/tree_ops.jl
@@ -90,8 +90,8 @@ end
 
 # Checks the distance function and add those points that are among the k best.
 # Uses a heap for fast insertion.
-@inline function add_points_knn!{T}(best_dists::Vector{T}, best_idxs::Vector{Int},
-                                   tree::NNTree{T}, index::Int, point::Vector{T},
+@inline function add_points_knn!{T, P, Tret}(best_dists::Vector{Tret}, best_idxs::Vector{Int},
+                                   tree::NNTree{T}, index::Int, point::Vector{P},
                                    do_end::Bool)
     for z in get_leaf_range(tree.tree_data, index)
         @POINT 1
@@ -111,8 +111,8 @@ end
 # stop computing the distance function as soon as we reach the desired radius.
 # This will probably prevent SIMD and other optimizations so some care is needed
 # to evaluate if it is worth it.
-@inline function add_points_inrange!{T}(idx_in_ball::Vector{Int}, tree::NNTree{T},
-                                       index::Int, point::Vector{T}, r::Number, do_end::Bool)
+function add_points_inrange!{T, P}(idx_in_ball::Vector{Int}, tree::NNTree{T},
+                                       index::Int, point::Vector{P}, r::Number, do_end::Bool)
     for z in get_leaf_range(tree.tree_data, index)
         @POINT 1
         idx = tree.reordered ? z : tree.indices[z]

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -1,5 +1,5 @@
 # Find the dimension witht the largest spread.
-function find_largest_spread{T}(data::Matrix{T}, indices, low, high)
+@inline function find_largest_spread{T}(data::Matrix{T}, indices, low, high)
     n_points = high - low + 1
     n_dim = size(data, 1)
     split_dim = 1
@@ -23,8 +23,8 @@ end
 
 # Taken from https://github.com/JuliaLang/julia/blob/v0.3.5/base/sort.jl
 # and modified to compare against a matrix
-@inline function select_spec!{T <: AbstractFloat}(v::AbstractVector, k::Int, lo::Int,
-                                          hi::Int, data::Matrix{T}, dim::Int)
+@inline function select_spec!(v::AbstractVector, k::Int, lo::Int,
+                              hi::Int, data::Matrix, dim::Int)
     @inbounds lo <= k <= hi || error("select index $k is out of range $lo:$hi")
      while lo < hi
         if hi-lo == 1


### PR DESCRIPTION
This is a work in progress to resolve #13 and an alternative to #14 

TODO:

- [ ] Check for any performance regressions. Since this mess around with the type system we have to make sure that no type instability got introduced.
- [ ] Add test cases, maybe @tlnagy can help with that.

Creating the tree works now at least:

```jl
julia> data = rand(1:4, (10, 10^4));

julia> balltree = BallTree(data, Hamming())
NearestNeighbors.BallTree{Int64,Float64,Distances.Hamming}
  Number of points: 10000
  Dimensions: 10
  Metric: Distances.Hamming()
  Reordered: true
```

cc @tlnagy 