### PR TITLE
Fallback slice-based methods for column-selecting evaluate(::Metric, …)

### DIFF
--- a/src/evaluation.jl
+++ b/src/evaluation.jl
@@ -42,6 +42,16 @@ function Distances.evaluate(d::Distances.UnionMetrics, a::AbstractMatrix,
     end
 end
 
+function Distances.evaluate(d::Distances.PreMetric, a::AbstractMatrix,
+                            b::AbstractArray, col::Int, do_end::Bool=true)
+    evaluate(d, slice(a, :, col), b)
+end
+
+function Distances.evaluate(d::Distances.PreMetric, a::AbstractMatrix,
+                            b::AbstractArray, col::Int, break_at::Number, do_end::Bool=true)
+    evaluate(d, slice(a, :, col), b)
+end
+
 @inline eval_pow(::MinkowskiMetric, s) = abs(s)
 @inline eval_pow(::Euclidean, s) = abs2(s)
 @inline eval_pow(d::Minkowski, s) = abs(s)^d.p

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,9 +7,13 @@ else
     const Test = BaseTestNext
 end
 
+import Distances: Metric, evaluate
+immutable CustomMetric <: Metric end
+evaluate(::CustomMetric, a::AbstractVector, b::AbstractVector) = norm(a - b)
+
 # TODO: Cityblock()
 const metrics = [Chebyshev(), Euclidean(), Minkowski(3.5)]
-const fullmetrics = [metrics; Hamming()]
+const fullmetrics = [metrics; Hamming(); CustomMetric()]
 const trees = [KDTree, BallTree]
 const trees_with_brute = [BruteTree; trees]
 


### PR DESCRIPTION
Fixes #18. To resolve some method ambiguity warnings I had to define ```evaluate``` for each type in UnionMetrics, which is a bit janky - it might be preferable/safer to replace ```Distances.UnionMetrics.types``` on [this line](https://github.com/schmrlng/NearestNeighbors.jl-1/blob/370d6cc1462e93398a862c830a1466467b5a6849/src/evaluation.jl#L9) with an explicit list of the types involved, but that would create the possibility of a de-sync with Distances.jl. I've run into similar issues before with type complements/intersections in two different arguments (the other culprit here is ```Bool <: Number``` for ```do_end``` and ```break_at```) and haven't come up with a better solution than janky enumeration - if you know of a better way I can implement that instead.

For the fallback method I went with ```Distances.Metric``` instead of ```Distances.SemiMetric``` or ```Distances.PreMetric```; if the data structure applies in either of the latter cases that might be worth changing.

I also added a rudimentary test.