### PR TITLE
Fix create_bsphere for metrics that are not translation-invariant or homogeneous

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,12 +8,24 @@ else
 end
 
 import Distances: Metric, evaluate
-immutable CustomMetric <: Metric end
-evaluate(::CustomMetric, a::AbstractVector, b::AbstractVector) = norm(a - b)
+immutable CustomMetric1 <: Metric end
+evaluate(::CustomMetric1, a::AbstractVector, b::AbstractVector) = maximum(abs(a - b))
+function NearestNeighbors.interpolate{T <: AbstractFloat}(::CustomMetric1,
+                                                          a::Vector{T},
+                                                          b::Vector{T},
+                                                          x,
+                                                          d)
+    idx = (abs(b - a) .>= d - x)
+    c = copy(a)
+    c[idx] = (1 - x / d) .* a[idx] + (x / d) .* b[idx]
+    return c, true
+end
+immutable CustomMetric2 <: Metric end
+evaluate(::CustomMetric2, a::AbstractVector, b::AbstractVector) = norm(a - b) / (norm(a) + norm(b))
 
 # TODO: Cityblock()
 const metrics = [Chebyshev(), Euclidean(), Minkowski(3.5)]
-const fullmetrics = [metrics; Hamming(); CustomMetric()]
+const fullmetrics = [metrics; Hamming(); CustomMetric1(); CustomMetric2()]
 const trees = [KDTree, BallTree]
 const trees_with_brute = [BruteTree; trees]
 

--- a/test/test_monkey.jl
+++ b/test/test_monkey.jl
@@ -10,6 +10,8 @@ import NearestNeighbors.MinkowskiMetric
             # and that it is the closest
             if TreeType == KDTree && !isa(metric, MinkowskiMetric)
                 continue
+            elseif TreeType == BallTree && isa(metric, Hamming)
+                continue
             end
             for i in 1:100
                 dim_data = rand(1:4)


### PR DESCRIPTION
The ```create_bsphere``` method [here](https://github.com/KristofferC/NearestNeighbors.jl/blob/master/src/hyperspheres.jl#L45) relies on the assumption that the metric is determined by a norm (that is, the metric is homogeneous and translation-invariant). This PR should let ```BallTree``` work with any metric.