### PR TITLE
Fix to stop KDTree from crashing when given empty data.

### DIFF
--- a/src/tree_data.jl
+++ b/src/tree_data.jl
@@ -12,6 +12,10 @@ end
 
 function TreeData(data, leafsize)
     n_dim, n_p = size(data)
+
+    # If number of points is zero
+    n_p == 0 && return TreeData(0, 0, 0, 0, 0, 0, 0, 0)
+
     n_leafs =  ceil(Integer, n_p / leafsize)
     n_internal_nodes = n_leafs - 1
     leafrow = floor(Integer, log2(n_leafs))
@@ -34,5 +38,3 @@ function TreeData(data, leafsize)
     TreeData(last_node_size, leafsize, n_leafs,
     n_internal_nodes, cross_node, k1, k2, last_full_node)
 end
-
-


### PR DESCRIPTION
Before:
```
julia> KDTree(randn(3,0))
ERROR: InexactError()
 in trunc at ./float.jl:379
 in call at /home/josh/.julia/v0.4/NearestNeighbors/src/tree_data.jl:17
 in KDTree at /home/josh/.julia/v0.4/NearestNeighbors/src/kd_tree.jl:36
 in KDTree at /home/josh/.julia/v0.4/NearestNeighbors/src/kd_tree.jl:34
```
After:
```
julia> KDTree(rand(3,0))
NearestNeighbors.KDTree{Float64,Distances.Euclidean}
  Number of points: 0
  Dimensions: 3
  Metric: Distances.Euclidean()
  Reordered: true
```