### PR TITLE
Better support for supplying a single SVector

### DIFF
--- a/src/NearestNeighbors.jl
+++ b/src/NearestNeighbors.jl
@@ -27,14 +27,14 @@ abstract NNTree{V <: AbstractVector, P <: Metric}
 
 typealias MinkowskiMetric Union{Euclidean, Chebyshev, Cityblock, Minkowski}
 
-function check_input{V1, V2 <: AbstractVector}(::NNTree{V1}, ::Vector{V2})
+function check_input{V1, V2 <: AbstractVector}(::NNTree{V1}, ::AbstractVector{V2})
     if length(V1) != length(V2)
         throw(ArgumentError(
             "dimension of input points:$(length(V2)) and tree data:$(length(V1)) must agree"))
     end
 end
 
-function check_input{V1, V2 <: Number}(::NNTree{V1}, point::Vector{V2})
+function check_input{V1, T <: Number}(::NNTree{V1}, point::AbstractVector{T})
     if length(V1) != length(point)
         throw(ArgumentError(
             "dimension of input points:$(length(point)) and tree data:$(length(V1)) must agree"))


### PR DESCRIPTION
Can call inrange, etc with a single static vector. Previously I had to wrap a 1-element vector with my query point and unwrap the output.