### PR TITLE
loosen compat requirement to 0.17

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.5
 Distances 0.4
 StaticArrays 0.0.4
-Compat 0.18.0
+Compat 0.17.0


### PR DESCRIPTION
no parametric type aliases are used here currently, only
0.17 is needed for abstract type syntax