### PR TITLE
use 0.6.0-pre as minimum julia version in REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.6-
+julia 0.6.0-pre
 Distances 0.4
 StaticArrays 0.0.4


### PR DESCRIPTION
`struct` and `abstract type` would not work in early 0.6.0-dev versions,
so better to stick with julia-0.5-compatible versions of the package there