### PR TITLE
remove BaseTestNext

### DIFF
--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,0 @@
-BaseTestNext

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,12 +1,7 @@
 using NearestNeighbors
 using StaticArrays
 
-if VERSION >= v"0.5-"
-    using Base.Test
-else
-    using BaseTestNext
-    const Test = BaseTestNext
-end
+using Base.Test
 
 import Distances: Metric, evaluate
 struct CustomMetric1 <: Metric end


### PR DESCRIPTION
No longer needed since current minimum supported julia version in REQUIRE is 0.6
