### PR TITLE
Add inrange2() to find points between two radiuses

### DIFF
--- a/src/NearestNeighbors.jl
+++ b/src/NearestNeighbors.jl
@@ -1,4 +1,4 @@
-__precompile__()
+# __precompile__()
 
 module NearestNeighbors
 
@@ -9,7 +9,7 @@ using StaticArrays
 import Base.show
 
 export BruteTree, KDTree, BallTree, DataFreeTree
-export knn, inrange # TODOs? , allpairs, distmat, npairs
+export knn, inrange, inrange2 # TODOs? , allpairs, distmat, npairs
 export injectdata
 
 export Euclidean,

--- a/src/NearestNeighbors.jl
+++ b/src/NearestNeighbors.jl
@@ -1,4 +1,4 @@
-# __precompile__()
+__precompile__()
 
 module NearestNeighbors
 

--- a/src/brute_tree.jl
+++ b/src/brute_tree.jl
@@ -73,3 +73,28 @@ function inrange_kernel!(tree::BruteTree,
         end
     end
 end
+
+# inrange with two radiuses
+function _inrange2(tree::BruteTree,
+                  point::AbstractVector,
+                  radius1::Number,
+                  radius2::Number,
+                  idx_in_ball::Vector{Int})
+    inrange_kernel2!(tree, point, radius1, radius2, idx_in_ball)
+    return
+end
+
+
+function inrange_kernel2!(tree::BruteTree,
+                         point::AbstractVector,
+                         r1::Number,
+                         r2::Number,
+                         idx_in_ball::Vector{Int})
+    for i in 1:length(tree.data)
+        @POINT 1
+        d = evaluate(tree.metric, tree.data[i], point)
+        if d >= r1 && d <= r2
+            push!(idx_in_ball, i)
+        end
+    end
+end

--- a/src/hyperspheres.jl
+++ b/src/hyperspheres.jl
@@ -13,10 +13,29 @@ HyperSphere(center::SVector{N,T1}, r::T2) where {N, T1, T2} = HyperSphere(center
     evaluate(m, s1.center, s2.center) <= s1.r + s2.r
 end
 
+# computer intersection between a solid sphere s1 and  hollow sphere (s2, s3)
+@inline function intersects2(m::M,
+                            s1::HyperSphere{N,T},
+                            s2::HyperSphere{N,T},
+                            s3::HyperSphere{N,T}) where {T <: AbstractFloat, N, M <: Metric}
+    outside_cut_s2 = evaluate(m, s1.center, s2.center) >= s2.r - s1.r
+    inside_cut_s3 = evaluate(m, s1.center, s3.center) <= s1.r + s3.r
+    return outside_cut_s2 && inside_cut_s3
+end
+
 @inline function encloses(m::M,
                           s1::HyperSphere{N,T},
                           s2::HyperSphere{N,T}) where {T <: AbstractFloat, N, M <: Metric}
     evaluate(m, s1.center, s2.center) + s1.r <= s2.r
+end
+
+@inline function encloses2(m::M,
+                          s1::HyperSphere{N,T},
+                          s2::HyperSphere{N,T},
+                          s3::HyperSphere{N,T}) where {T <: AbstractFloat, N, M <: Metric}
+    inside_s3 = evaluate(m, s1.center, s3.center) + s1.r <= s2.r
+    outside_s2 = evaluate(m, s1.center, s2.center) >= s1.r + s2.r
+    return outside_s2 && inside_s3
 end
 
 @inline function interpolate(::M,

--- a/src/inrange.jl
+++ b/src/inrange.jl
@@ -57,7 +57,7 @@ end
 """
     inrange2(tree::NNTree, points, radius1, radius2, [, sortres=false]) -> indices
 
-Find all the points in the tree lying between two `radius1` and `radius2` from
+Find all the points in the tree lying between `radius1` and `radius2` from
 given `points`. If `sortres = true` the resulting indices are sorted.
 """
 function inrange2(tree::NNTree,

--- a/src/inrange.jl
+++ b/src/inrange.jl
@@ -1,4 +1,6 @@
 check_radius(r) = r < 0 && throw(ArgumentError("the query radius r must be ≧ 0"))
+check_radiuses(r1, r2) = (r1 > r2 || r1 < 0 || r2 < 0) &&
+            throw(ArgumentError("the query radiuses must be ≧ 0 and r1 <= r2"))
 
 """
     inrange(tree::NNTree, points, radius [, sortres=false]) -> indices
@@ -49,4 +51,60 @@ function inrange(tree::NNTree{V}, point::Matrix{T}, radius::Number, sortres=fals
         new_data = SVector{dim,T}[SVector{dim,T}(point[:, i]) for i in 1:npoints]
     end
     inrange(tree, new_data, radius, sortres)
+end
+
+
+"""
+    inrange2(tree::NNTree, points, radius1, radius2, [, sortres=false]) -> indices
+
+Find all the points in the tree lying between two `radius1` and `radius2` from
+given `points`. If `sortres = true` the resulting indices are sorted.
+"""
+function inrange2(tree::NNTree,
+                 points::Vector{T},
+                 radius1::Number,
+                 radius2::Number,
+                 sortres=false) where {T <: AbstractVector}
+    check_input(tree, points)
+    check_radiuses(radius1, radius2)
+
+    idxs = [Vector{Int}() for _ in 1:length(points)]
+
+    for i in 1:length(points)
+        inrange_point2!(tree, points[i], radius1, radius2, sortres, idxs[i])
+    end
+    return idxs
+end
+
+function inrange_point2!(tree, point, radius1, radius2, sortres, idx)
+    _inrange2(tree, point, radius1, radius2, idx)
+    if tree.reordered
+        @inbounds for j in 1:length(idx)
+            idx[j] = tree.indices[idx[j]]
+        end
+    end
+    sortres && sort!(idx)
+    return
+end
+
+function inrange2(tree::NNTree{V}, point::AbstractVector{T},
+                      radius1::Number, radius2::Number,
+                      sortres=false) where {V, T <: Number}
+    check_input(tree, point)
+    check_radiuses(radius1, radius2)
+    idx = Int[]
+    inrange_point2!(tree, point, radius1, radius2, sortres, idx)
+    return idx
+end
+
+function inrange2(tree::NNTree{V}, point::Matrix{T}, radius1::Number,
+                 radius2::Number, sortres=false) where {V, T <: Number}
+    dim = size(point, 1)
+    npoints = size(point, 2)
+    if isbits(T)
+        new_data = reinterpret(SVector{dim,T}, point, (length(point) ÷ dim,))
+    else
+        new_data = SVector{dim,T}[SVector{dim,T}(point[:, i]) for i in 1:npoints]
+    end
+    inrange2(tree, new_data, radius1, radius2, sortres)
 end

--- a/src/tree_ops.jl
+++ b/src/tree_ops.jl
@@ -127,6 +127,20 @@ end
     end
 end
 
+# Add those points in the leaf node that are within range of two radiuses.
+@inline function add_points_inrange2!(idx_in_ball::Vector{Int}, tree::NNTree,
+                                     index::Int, point::AbstractVector,
+                                     r1::Number, r2::Number, do_end::Bool)
+    for z in get_leaf_range(tree.tree_data, index)
+        @POINT 1
+        idx = tree.reordered ? z : tree.indices[z]
+        dist_d = evaluate(tree.metric, tree.data[idx], point, do_end)
+        if dist_d >= r1 && dist_d <= r2
+            push!(idx_in_ball, idx)
+        end
+    end
+end
+
 # Add all points in this subtree since we have determined
 # they are all within the desired range
 function addall(tree::NNTree, index::Int, idx_in_ball::Vector{Int})

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,7 +26,7 @@ const fullmetrics = [metrics; Hamming(); CustomMetric1(); CustomMetric2()]
 const trees = [KDTree, BallTree]
 const trees_with_brute = [BruteTree; trees]
 
-include("test_knn.jl")
+# include("test_knn.jl")
 include("test_inrange.jl")
-include("test_monkey.jl")
-include("test_datafreetree.jl")
+# include("test_monkey.jl")
+# include("test_datafreetree.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,7 +26,7 @@ const fullmetrics = [metrics; Hamming(); CustomMetric1(); CustomMetric2()]
 const trees = [KDTree, BallTree]
 const trees_with_brute = [BruteTree; trees]
 
-# include("test_knn.jl")
+include("test_knn.jl")
 include("test_inrange.jl")
-# include("test_monkey.jl")
-# include("test_datafreetree.jl")
+include("test_monkey.jl")
+include("test_datafreetree.jl")

--- a/test/test_inrange.jl
+++ b/test/test_inrange.jl
@@ -42,12 +42,16 @@
             idxs = inrange(empty_tree, [0.5, 0.5, 0.5], 1.0)
             @test idxs == []
 
-            # test inrange for points between two radiuses
+            # test inrange2 for points between two radiuses
             idxs = inrange2(tree, [1.1, 1.1, 1.1], 0.2, 1.2, dosort)
             @test idxs == [4, 6, 7] # Corners 1,2, 3, 5 and 8 are outside range
 
-            idxs = inrange2(tree, [1.1, 1.1, 1.1], 0.2, 1.5, dosort)
+            idxs = inrange2(tree, [1.1, 1.1, 1.1], 0.2, 1.6, dosort)
             @test idxs == [2, 3, 4, 5, 6, 7] # Corners 1 and 8 are outside range
+
+            idxs = inrange2(tree, [0.0 0.0; 0.0 0.0; 0.5 0.0], 0.6, 1.2, dosort)
+            @test idxs[1] == [3, 4, 5, 6] # these all has distance of 1.118 [0,0,0.5]
+            @test idxs[2] == [2, 3, 5] # these all have distance of 1.0 from [0,0,0]
         end
     end
 end

--- a/test/test_inrange.jl
+++ b/test/test_inrange.jl
@@ -41,6 +41,13 @@
             empty_tree = TreeType(rand(3,0), metric)
             idxs = inrange(empty_tree, [0.5, 0.5, 0.5], 1.0)
             @test idxs == []
+
+            # test inrange for points between two radiuses
+            idxs = inrange2(tree, [1.1, 1.1, 1.1], 0.2, 1.2, dosort)
+            @test idxs == [4, 6, 7] # Corners 1,2, 3, 5 and 8 are outside range
+
+            idxs = inrange2(tree, [1.1, 1.1, 1.1], 0.2, 1.5, dosort)
+            @test idxs == [2, 3, 4, 5, 6, 7] # Corners 1 and 8 are outside range
         end
     end
 end


### PR DESCRIPTION
This is useful when searching for points at a radius from fixed position with a tolerance. This is equivalent to, but more efficient than, using two inrange() operations for two different radiuses and then finding point that belong to only the larger radius.