### PR TITLE
Added handling for single point presented as Vector

### DIFF
--- a/src/ball_tree.jl
+++ b/src/ball_tree.jl
@@ -81,7 +81,7 @@ function BallTree(data::AbstractVector{V},
     BallTree(storedata ? data : similar(data, 0), hyper_spheres, indices, metric, tree_data, reorder)
 end
 
- function BallTree(data::AbstractMatrix{T},
+function BallTree(data::VecOrMat{T},
                   metric::M = Euclidean();
                   leafsize::Int = 10,
                   storedata::Bool = true,
@@ -97,16 +97,6 @@ end
     end
     BallTree(points, metric, leafsize = leafsize, storedata = storedata, reorder = reorder,
             reorderbuffer = reorderbuffer_points)
-end
-
-function BallTree(data::Vector{T},
-                  metric::M = Euclidean();
-                  leafsize::Int = 10,
-                  storedata::Bool = true,
-                  reorder::Bool = true,
-                  reorderbuffer::Vector{T} = Vector{T}(undef, 0, 0)) where {T <: AbstractFloat, M <: Metric}
-    BallTree(reshape(data, length(data), 1), metric, leafsize = leafsize,
-             storedata = storedata, reorder = reorder, reorderbuffer = reorderbuffer);
 end
 
 # Recursive function to build the tree.

--- a/src/ball_tree.jl
+++ b/src/ball_tree.jl
@@ -105,7 +105,8 @@ function BallTree(data::Vector{T},
                   storedata::Bool = true,
                   reorder::Bool = true,
                   reorderbuffer::Vector{T} = Vector{T}(undef, 0, 0)) where {T <: AbstractFloat, M <: Metric}
-    BallTree(hcat(data), metric, leafsize = leafsize, storedata = storedata, reorder = reorder, reorderbuffer = reorderbuffer);
+    BallTree(reshape(data, length(data), 1), metric, leafsize = leafsize,
+             storedata = storedata, reorder = reorder, reorderbuffer = reorderbuffer);
 end
 
 # Recursive function to build the tree.

--- a/src/ball_tree.jl
+++ b/src/ball_tree.jl
@@ -66,7 +66,7 @@ function BallTree(data::AbstractVector{V},
                 "dimension of input points:$(length(V)) and metric parameter:$(length(p)) must agree"))
         end
     end
-    
+
     if n_p > 0
         # Call the recursive BallTree builder
         build_BallTree(1, data, data_reordered, hyper_spheres, metric, indices, indices_reordered,
@@ -81,7 +81,7 @@ function BallTree(data::AbstractVector{V},
     BallTree(storedata ? data : similar(data, 0), hyper_spheres, indices, metric, tree_data, reorder)
 end
 
-function BallTree(data::VecOrMat{T},
+function BallTree(data::AbstractVecOrMat{T},
                   metric::M = Euclidean();
                   leafsize::Int = 10,
                   storedata::Bool = true,

--- a/src/ball_tree.jl
+++ b/src/ball_tree.jl
@@ -99,6 +99,15 @@ end
             reorderbuffer = reorderbuffer_points)
 end
 
+function BallTree(data::Vector{T},
+                  metric::M = Euclidean();
+                  leafsize::Int = 10,
+                  storedata::Bool = true,
+                  reorder::Bool = true,
+                  reorderbuffer::Vector{T} = Vector{T}(undef, 0, 0)) where {T <: AbstractFloat, M <: Metric}
+    BallTree(hcat(data), metric, leafsize = leafsize, storedata = storedata, reorder = reorder, reorderbuffer = reorderbuffer);
+end
+
 # Recursive function to build the tree.
 function build_BallTree(index::Int,
                         data::Vector{V},

--- a/src/brute_tree.jl
+++ b/src/brute_tree.jl
@@ -32,7 +32,7 @@ end
 
 function BruteTree(data::Vector{T}, metric::Metric = Euclidean();
                    reorder::Bool=false, leafsize::Int=0, storedata::Bool=true) where {T}
-    BruteTree(hcat(data),
+    BruteTree(reshape(data, length(data), 1),
               metric, reorder = reorder, leafsize = leafsize, storedata = storedata));
 end
 

--- a/src/brute_tree.jl
+++ b/src/brute_tree.jl
@@ -22,8 +22,8 @@ function BruteTree(data::AbstractVector{V}, metric::Metric = Euclidean();
     BruteTree(storedata ? data : Vector{V}(), metric, reorder)
 end
 
-function BruteTree(data::VecOrMat{T}, metric::Metric = Euclidean();
-                   reorder::Bool=false, leafsize::Int=0, storedata::Bool=true) where {T}
+function BruteTree(data::AbstractVecOrMat{T}, metric::Metric = Euclidean();
+                   reorder::Bool=false, leafsize::Int=0, storedata::Bool=true) where {T <: AbstractFloat}
     dim = size(data, 1)
     npoints = size(data, 2)
     BruteTree(copy_svec(T, data, Val(dim)),

--- a/src/brute_tree.jl
+++ b/src/brute_tree.jl
@@ -33,7 +33,7 @@ end
 function BruteTree(data::Vector{T}, metric::Metric = Euclidean();
                    reorder::Bool=false, leafsize::Int=0, storedata::Bool=true) where {T}
     BruteTree(reshape(data, length(data), 1),
-              metric, reorder = reorder, leafsize = leafsize, storedata = storedata));
+              metric, reorder = reorder, leafsize = leafsize, storedata = storedata);
 end
 
 function _knn(tree::BruteTree{V},

--- a/src/brute_tree.jl
+++ b/src/brute_tree.jl
@@ -30,6 +30,12 @@ function BruteTree(data::AbstractMatrix{T}, metric::Metric = Euclidean();
               metric, reorder = reorder, leafsize = leafsize, storedata = storedata)
 end
 
+function BruteTree(data::Vector{T}, metric::Metric = Euclidean();
+                   reorder::Bool=false, leafsize::Int=0, storedata::Bool=true) where {T}
+    BruteTree(hcat(data),
+              metric, reorder = reorder, leafsize = leafsize, storedata = storedata));
+end
+
 function _knn(tree::BruteTree{V},
                  point::AbstractVector,
                  best_idxs::Vector{Int},

--- a/src/brute_tree.jl
+++ b/src/brute_tree.jl
@@ -23,7 +23,7 @@ function BruteTree(data::AbstractVector{V}, metric::Metric = Euclidean();
 end
 
 function BruteTree(data::AbstractVecOrMat{T}, metric::Metric = Euclidean();
-                   reorder::Bool=false, leafsize::Int=0, storedata::Bool=true) where {T <: AbstractFloat}
+                   reorder::Bool=false, leafsize::Int=0, storedata::Bool=true) where {T}
     dim = size(data, 1)
     npoints = size(data, 2)
     BruteTree(copy_svec(T, data, Val(dim)),

--- a/src/brute_tree.jl
+++ b/src/brute_tree.jl
@@ -22,18 +22,12 @@ function BruteTree(data::AbstractVector{V}, metric::Metric = Euclidean();
     BruteTree(storedata ? data : Vector{V}(), metric, reorder)
 end
 
-function BruteTree(data::AbstractMatrix{T}, metric::Metric = Euclidean();
+function BruteTree(data::VecOrMat{T}, metric::Metric = Euclidean();
                    reorder::Bool=false, leafsize::Int=0, storedata::Bool=true) where {T}
     dim = size(data, 1)
     npoints = size(data, 2)
     BruteTree(copy_svec(T, data, Val(dim)),
               metric, reorder = reorder, leafsize = leafsize, storedata = storedata)
-end
-
-function BruteTree(data::Vector{T}, metric::Metric = Euclidean();
-                   reorder::Bool=false, leafsize::Int=0, storedata::Bool=true) where {T}
-    BruteTree(reshape(data, length(data), 1),
-              metric, reorder = reorder, leafsize = leafsize, storedata = storedata);
 end
 
 function _knn(tree::BruteTree{V},

--- a/src/kd_tree.jl
+++ b/src/kd_tree.jl
@@ -89,7 +89,7 @@ end
         reorderbuffer_points = copy_svec(T, reorderbuffer, Val(dim))
     end
     KDTree(points, metric, leafsize = leafsize, storedata = storedata, reorder = reorder,
-            reorderbuffer = reorderbuffer_points)
+           reorderbuffer = reorderbuffer_points)
 end
 
 function KDTree(data::Vector{T},
@@ -98,8 +98,8 @@ function KDTree(data::Vector{T},
                 storedata::Bool = true,
                 reorder::Bool = true,
                 reorderbuffer::Vector{T} = Vector{T}(undef, 0, 0)) where {T <: AbstractFloat, M <: MinkowskiMetric}
-   KDTree(hcat(data), metric, leafsize = leafsize, storedata = storedata, reorder = reorder,
-           reorderbuffer = reorderbuffer_points)
+   KDTree(reshape(data, length(data), 1), metric, leafsize = leafsize, storedata = storedata,
+          reorder = reorder, reorderbuffer = reorderbuffer_points)
 end
 
 function build_KDTree(index::Int,

--- a/src/kd_tree.jl
+++ b/src/kd_tree.jl
@@ -92,6 +92,16 @@ end
             reorderbuffer = reorderbuffer_points)
 end
 
+function KDTree(data::Vector{T},
+                metric::M = Euclidean();
+                leafsize::Int = 10,
+                storedata::Bool = true,
+                reorder::Bool = true,
+                reorderbuffer::Vector{T} = Vector{T}(undef, 0, 0)) where {T <: AbstractFloat, M <: MinkowskiMetric}
+   KDTree(hcat(data), metric, leafsize = leafsize, storedata = storedata, reorder = reorder,
+           reorderbuffer = reorderbuffer_points)
+end
+
 function build_KDTree(index::Int,
                       data::AbstractVector{V},
                       data_reordered::Vector{V},

--- a/src/kd_tree.jl
+++ b/src/kd_tree.jl
@@ -74,12 +74,12 @@ function KDTree(data::AbstractVector{V},
     KDTree(storedata ? data : similar(data, 0), hyper_rec, indices, metric, nodes, tree_data, reorder)
 end
 
- function KDTree(data::AbstractMatrix{T},
-                metric::M = Euclidean();
-                leafsize::Int = 10,
-                storedata::Bool = true,
-                reorder::Bool = true,
-                reorderbuffer::Matrix{T} = Matrix{T}(undef, 0, 0)) where {T <: AbstractFloat, M <: MinkowskiMetric}
+ function KDTree(data::VecOrMat{T},
+                 metric::M = Euclidean();
+                 leafsize::Int = 10,
+                 storedata::Bool = true,
+                 reorder::Bool = true,
+                 reorderbuffer::Matrix{T} = Matrix{T}(undef, 0, 0)) where {T <: AbstractFloat, M <: MinkowskiMetric}
     dim = size(data, 1)
     npoints = size(data, 2)
     points = copy_svec(T, data, Val(dim))
@@ -90,16 +90,6 @@ end
     end
     KDTree(points, metric, leafsize = leafsize, storedata = storedata, reorder = reorder,
            reorderbuffer = reorderbuffer_points)
-end
-
-function KDTree(data::Vector{T},
-                metric::M = Euclidean();
-                leafsize::Int = 10,
-                storedata::Bool = true,
-                reorder::Bool = true,
-                reorderbuffer::Vector{T} = Vector{T}(undef, 0, 0)) where {T <: AbstractFloat, M <: MinkowskiMetric}
-   KDTree(reshape(data, length(data), 1), metric, leafsize = leafsize, storedata = storedata,
-          reorder = reorder, reorderbuffer = reorderbuffer_points)
 end
 
 function build_KDTree(index::Int,

--- a/src/kd_tree.jl
+++ b/src/kd_tree.jl
@@ -70,11 +70,11 @@ function KDTree(data::AbstractVector{V},
                 "dimension of input points:$(length(V)) and metric parameter:$(length(p)) must agree"))
         end
     end
-    
+
     KDTree(storedata ? data : similar(data, 0), hyper_rec, indices, metric, nodes, tree_data, reorder)
 end
 
- function KDTree(data::VecOrMat{T},
+ function KDTree(data::AbstractVecOrMat{T},
                  metric::M = Euclidean();
                  leafsize::Int = 10,
                  storedata::Bool = true,

--- a/test/test_inrange.jl
+++ b/test/test_inrange.jl
@@ -41,6 +41,10 @@
                 empty_tree = TreeType(rand(3,0), metric)
                 idxs = inrange(empty_tree, [0.5, 0.5, 0.5], 1.0)
                 @test idxs == []
+
+                one_point_tree = TreeType([0.5, 0.5, 0.5], metric)
+                idxs = inrange(one_point_tree, data, 1.0)
+                @test idxs == repeat([[1]], size(data, 2))
             end
             data = [0.0 0.0 0.0 0.0 1.0 1.0 1.0 1.0;
                     0.0 0.0 1.0 1.0 0.0 0.0 1.0 1.0;

--- a/test/test_knn.jl
+++ b/test/test_knn.jl
@@ -39,6 +39,12 @@ import Distances.evaluate
                 @test idxs == Int[]
                 @test_throws ArgumentError knn(empty_tree, [0.1, 0.8], -1) # k < 0
                 @test_throws ArgumentError knn(empty_tree, [0.1, 0.8], 1)  # k > n_points
+
+                one_point_tree = TreeType([0.2, 0.8], metric)
+                idxs, dists = knn(one_point_tree, data, 1)
+                @test idxs == repeat([[1]], size(data, 2))
+                @test_throws ArgumentError knn(one_point_tree, [0.1, 0.8], -1) # k < 0
+                @test_throws ArgumentError knn(one_point_tree, [0.1, 0.8], 2)  # k > n_points
             end
             # 8 node rectangle
             data = [0.0 0.0 0.0 0.5 0.5 1.0 1.0 1.0;


### PR DESCRIPTION
Added Tree constructors that accept a Vector, convert it to a Matrix via `reshape`, and pass it along to the Matrix-oriented constructors. Also a couple formatting nits.

Fixes suggestion #76
