### PR TITLE
Added convenience functions for 1 nearest neighbor

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ example if iterating over points and a point has already been visited.
 It is generally better for performance to query once with a large number of points than to query multiple
 times with one point per query.
 
+As a convenience, if you only want the closest nearest neighbor, you can call `nn` instead for a cleaner result:
+
+```jl
+nn(tree, points, skip = always_false) -> idxs, dists
+```
+
 Some examples:
 
 ```jl
@@ -84,7 +90,7 @@ idxs
 dists
 # 3-element Array{Float64,1}:
 #  0.039032201026256215
-#  0.04134193711411951 
+#  0.04134193711411951
 #  0.042974090446474184
 
 # Multiple points
@@ -103,9 +109,9 @@ idxs
 # 4-element Array{Array{Float64,1},1}:
 #  [0.0298932, 0.0327349, 0.0365979]
 #  [0.0348751, 0.0498355, 0.0506802]
-#  [0.0318547, 0.037291, 0.0421208] 
+#  [0.0318547, 0.037291, 0.0421208]
 #  [0.03321, 0.0360935, 0.0411951]
- 
+
 # Static vectors
 v = @SVector[0.5, 0.3, 0.2];
 
@@ -119,8 +125,8 @@ idxs
 
 dists
 # 3-element Array{Float64,1}:
-#  0.04178677766255837 
-#  0.04556078331418939 
+#  0.04178677766255837
+#  0.04556078331418939
 #  0.049967238112417205
 ```
 

--- a/src/NearestNeighbors.jl
+++ b/src/NearestNeighbors.jl
@@ -7,7 +7,7 @@ using StaticArrays
 import Base.show
 
 export NNTree, BruteTree, KDTree, BallTree, DataFreeTree
-export knn, inrange # TODOs? , allpairs, distmat, npairs
+export knn, nn, inrange # TODOs? , allpairs, distmat, npairs
 export injectdata
 
 export Euclidean,

--- a/src/knn.jl
+++ b/src/knn.jl
@@ -6,6 +6,7 @@ end
 
 """
     knn(tree::NNTree, points, k [, sortres=false]) -> indices, distances
+    nn(tree:NNTree, points) -> indices, distances
 
 Performs a lookup of the `k` nearest neigbours to the `points` from the data
 in the `tree`. If `sortres = true` the result is sorted such that the results are
@@ -54,4 +55,19 @@ function knn(tree::NNTree{V}, point::AbstractMatrix{T}, k::Int, sortres=false, s
         new_data = SVector{dim,T}[SVector{dim,T}(point[:, i]) for i in 1:npoints]
     end
     knn(tree, new_data, k, sortres, skip)
+end
+
+function nn(tree::NNTree{V}, points::Vector{T}, skip::Function=always_false) where {V, T <: AbstractVector}
+    idx, dist = knn(tree, points, 1, false, skip)
+    return first.(idx), first.(dist)
+end
+
+function nn(tree::NNTree{V}, points::AbstractVector{T}, skip::Function=always_false) where {V, T <: Number}
+    idx, dist = knn(tree, points, 1, false, skip)
+    return first(idx), first(dist)
+end
+
+function nn(tree::NNTree{V}, points::Matrix{T}, skip::Function=always_false) where {V, T <: Number}
+    idx, dist = knn(tree, points, 1, false, skip)
+    return first.(idx), first.(dist)
 end

--- a/src/knn.jl
+++ b/src/knn.jl
@@ -57,7 +57,7 @@ function knn(tree::NNTree{V}, point::AbstractMatrix{T}, k::Int, sortres=false, s
     knn(tree, new_data, k, sortres, skip)
 end
 
-nn(tree::NNTree{V}, points::AbstractVector{T}, skip::Function=always_false) where {V, T <: Number}       = _nn(tree, points, skip) .|> first
+nn(tree::NNTree{V}, points::AbstractVector{T}, skip::Function=always_false) where {V, T <: Number}         = _nn(tree, points, skip) .|> first
 nn(tree::NNTree{V}, points::AbstractVector{T}, skip::Function=always_false) where {V, T <: AbstractVector} = _nn(tree, points, skip)  |> _firsteach
 nn(tree::NNTree{V}, points::AbstractMatrix{T}, skip::Function=always_false) where {V, T <: Number}         = _nn(tree, points, skip)  |> _firsteach
 

--- a/src/knn.jl
+++ b/src/knn.jl
@@ -57,7 +57,7 @@ function knn(tree::NNTree{V}, point::AbstractMatrix{T}, k::Int, sortres=false, s
     knn(tree, new_data, k, sortres, skip)
 end
 
-nn(tree::NNTree{V}, points::AbstractVecOrMat{T}, skip::Function=always_false) where {V, T <: Number}       = _nn(tree, points, skip) .|> first
+nn(tree::NNTree{V}, points::AbstractVector{T}, skip::Function=always_false) where {V, T <: Number}       = _nn(tree, points, skip) .|> first
 nn(tree::NNTree{V}, points::AbstractVector{T}, skip::Function=always_false) where {V, T <: AbstractVector} = _nn(tree, points, skip)  |> _firsteach
 nn(tree::NNTree{V}, points::AbstractMatrix{T}, skip::Function=always_false) where {V, T <: Number}         = _nn(tree, points, skip)  |> _firsteach
 

--- a/src/knn.jl
+++ b/src/knn.jl
@@ -57,7 +57,7 @@ function knn(tree::NNTree{V}, point::AbstractMatrix{T}, k::Int, sortres=false, s
     knn(tree, new_data, k, sortres, skip)
 end
 
-function nn(tree::NNTree{V}, points::Vector{T}, skip::Function=always_false) where {V, T <: AbstractVector}
+function nn(tree::NNTree{V}, points::AbstractVector{T}, skip::Function=always_false) where {V, T <: AbstractVector}
     idx, dist = knn(tree, points, 1, false, skip)
     return first.(idx), first.(dist)
 end
@@ -67,7 +67,7 @@ function nn(tree::NNTree{V}, points::AbstractVector{T}, skip::Function=always_fa
     return first(idx), first(dist)
 end
 
-function nn(tree::NNTree{V}, points::Matrix{T}, skip::Function=always_false) where {V, T <: Number}
+function nn(tree::NNTree{V}, points::AbstractMatrix{T}, skip::Function=always_false) where {V, T <: Number}
     idx, dist = knn(tree, points, 1, false, skip)
     return first.(idx), first.(dist)
 end

--- a/src/knn.jl
+++ b/src/knn.jl
@@ -58,9 +58,9 @@ function knn(tree::NNTree{V}, point::AbstractMatrix{T}, k::Int, sortres=false, s
 end
 
 nn(tree::NNTree{V}, points::AbstractVecOrMat{T}, skip::Function=always_false) where {V, T <: Number}       = _nn(tree, points, skip) .|> first
-nn(tree::NNTree{V}, points::AbstractVector{T}, skip::Function=always_false) where {V, T <: AbstractVector} = _nn(tree, points, skip)  |> firsteach
-nn(tree::NNTree{V}, points::AbstractMatrix{T}, skip::Function=always_false) where {V, T <: Number}         = _nn(tree, points, skip)  |> firsteach
+nn(tree::NNTree{V}, points::AbstractVector{T}, skip::Function=always_false) where {V, T <: AbstractVector} = _nn(tree, points, skip)  |> _firsteach
+nn(tree::NNTree{V}, points::AbstractMatrix{T}, skip::Function=always_false) where {V, T <: Number}         = _nn(tree, points, skip)  |> _firsteach
 
 _nn(tree, points, skip) = knn(tree, points, 1, false, skip)
 
-firsteach(v::Tuple) = first.(first(v)), first.(last(v))
+_firsteach(v::Tuple) = first.(first(v)), first.(last(v))

--- a/src/knn.jl
+++ b/src/knn.jl
@@ -57,17 +57,10 @@ function knn(tree::NNTree{V}, point::AbstractMatrix{T}, k::Int, sortres=false, s
     knn(tree, new_data, k, sortres, skip)
 end
 
-function nn(tree::NNTree{V}, points::AbstractVector{T}, skip::Function=always_false) where {V, T <: AbstractVector}
-    idx, dist = knn(tree, points, 1, false, skip)
-    return first.(idx), first.(dist)
-end
+nn(tree::NNTree{V}, points::AbstractVecOrMat{T}, skip::Function=always_false) where {V, T <: Number}       = _nn(tree, points, skip) .|> first
+nn(tree::NNTree{V}, points::AbstractVector{T}, skip::Function=always_false) where {V, T <: AbstractVector} = _nn(tree, points, skip)  |> firsteach
+nn(tree::NNTree{V}, points::AbstractMatrix{T}, skip::Function=always_false) where {V, T <: Number}         = _nn(tree, points, skip)  |> firsteach
 
-function nn(tree::NNTree{V}, points::AbstractVector{T}, skip::Function=always_false) where {V, T <: Number}
-    idx, dist = knn(tree, points, 1, false, skip)
-    return first(idx), first(dist)
-end
+_nn(tree, points, skip) = knn(tree, points, 1, false, skip)
 
-function nn(tree::NNTree{V}, points::AbstractMatrix{T}, skip::Function=always_false) where {V, T <: Number}
-    idx, dist = knn(tree, points, 1, false, skip)
-    return first.(idx), first.(dist)
-end
+firsteach(v::Tuple) = first.(first(v)), first.(last(v))

--- a/test/test_knn.jl
+++ b/test/test_knn.jl
@@ -12,12 +12,12 @@ import Distances.evaluate
                 @test idxs[1] == 8 # Should be closest to top right corner
                 @test evaluate(metric, [0.2, 0.2], zeros(2)) ≈ dists[1]
 
-                idxs, dists = knn(tree, [0.1, 0.8], 3, true)
-                @test idxs == [3, 2, 5]
-
                 idxs, dists = nn(tree, [0.8, 0.8])
                 @test idxs == 8
                 @test evaluate(metric, [0.2, 0.2], zeros(2)) ≈ dists
+
+                idxs, dists = knn(tree, [0.1, 0.8], 3, true)
+                @test idxs == [3, 2, 5]
 
                 X = [0.8 0.1; 0.8 0.8]
                 idxs1, dists1 = knn(tree, X, 1, true)
@@ -40,9 +40,6 @@ import Distances.evaluate
                 @test idxs[2] == 3
 
                 idxs, dists = knn(tree, [1//10, 8//10], 3, true)
-                @test idxs == [3, 2, 5]
-
-                idxs, dists = nn(tree, [1//10, 8//10], 3, true)
                 @test idxs == [3, 2, 5]
 
                 @test_throws ArgumentError knn(tree, [0.1, 0.8], -1) # k < 0

--- a/test/test_knn.jl
+++ b/test/test_knn.jl
@@ -15,6 +15,10 @@ import Distances.evaluate
                 idxs, dists = knn(tree, [0.1, 0.8], 3, true)
                 @test idxs == [3, 2, 5]
 
+                idxs, dists = nn(tree, [0.8, 0.8])
+                @test idxs == 8
+                @test evaluate(metric, [0.2, 0.2], zeros(2)) ≈ dists
+
                 X = [0.8 0.1; 0.8 0.8]
                 idxs1, dists1 = knn(tree, X, 1, true)
                 idxs2, dists2 = knn(tree, view(X,:,1:2), 1, true)
@@ -23,11 +27,22 @@ import Distances.evaluate
                 @test idxs1[1][1] == 8
                 @test idxs1[2][1] == 3
 
+                idxs, dists = nn(tree, X)
+                @test idxs[1] == 8
+                @test idxs[2] == 3
+
                 idxs, dists = knn(tree, [SVector{2, Float64}(0.8,0.8), SVector{2, Float64}(0.1,0.8)], 1, true)
                 @test idxs[1][1] == 8
                 @test idxs[2][1] == 3
 
+                idxs, dists = nn(tree, [SVector{2, Float64}(0.8,0.8), SVector{2, Float64}(0.1,0.8)])
+                @test idxs[1] == 8
+                @test idxs[2] == 3
+
                 idxs, dists = knn(tree, [1//10, 8//10], 3, true)
+                @test idxs == [3, 2, 5]
+
+                idxs, dists = nn(tree, [1//10, 8//10], 3, true)
                 @test idxs == [3, 2, 5]
 
                 @test_throws ArgumentError knn(tree, [0.1, 0.8], -1) # k < 0


### PR DESCRIPTION
If a user wants a single nearest neighbor, unwrapping the return values is a bit cumbersome, when this can be transparently handled by the package instead.

I've added `nn` functions for this purpose, which pass the data along to `knn` with `k = 1` function and unwraps the results.

Also added tests for same.

Open to renaming them `knn` for consistency. EDIT: But I guess that would make the result type-unstable, and thus shouldn't be done.