### PR TITLE
WIP: Add non-allocating in-place knn!

### DIFF
--- a/src/NearestNeighbors.jl
+++ b/src/NearestNeighbors.jl
@@ -9,7 +9,7 @@ using StaticArrays
 import Base.show
 
 export NNTree, BruteTree, KDTree, BallTree, DataFreeTree
-export knn, inrange # TODOs? , allpairs, distmat, npairs
+export knn, knn!, inrange # TODOs? , allpairs, distmat, npairs
 export injectdata
 
 export Euclidean,


### PR DESCRIPTION
This PR is a work-in-progress to fix #81.

The time required to run the benchmark below is almost the same as you pointed out in that issue, but the non-allocating version is good to have in order to avoid unnecessary memory consumption in large loops:

```julia
using NearestNeighbors
using Random

function f1()
    k = 100
    Random.seed!(123)
    kdtree = KDTree(rand(3,1000))
    for i in 1:1000
        idxs, dists = knn(kdtree, rand(3,1000), k, true)
    end
end

function f2()
    k = 100
    Random.seed!(123)
    kdtree = KDTree(rand(3,1000))
    idxs  = [Vector{Int}(undef, k) for i in 1:1000]
    dists = [Vector{Float64}(undef, k) for i in 1:1000]
    for i in 1:1000
        knn!(idxs, dists, kdtree, rand(3,1000), k, true)
    end
end

@time f1()
@time f2()

10.900519 seconds (4.08 M allocations: 1.778 GiB, 0.71% gc time)
10.741283 seconds (2.24 M allocations: 105.810 MiB, 0.14% gc time)
```

Could you please review the changes, before I continue working? The version with a single point query is missing a non-allocating counterpart still, and we need documentation as well.