### PR TITLE
Accept AbstractArray data (e.g. views)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "julia.environmentPath": "/Users/pablo/.julia/environments/v1.4"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "julia.environmentPath": "/Users/pablo/.julia/environments/v1.4"
-}

--- a/src/ball_tree.jl
+++ b/src/ball_tree.jl
@@ -28,7 +28,7 @@ end
 
 Creates a `BallTree` from the data using the given `metric` and `leafsize`.
 """
-function BallTree(data::Vector{V},
+function BallTree(data::AbstractVector{V},
                   metric::M = Euclidean();
                   leafsize::Int = 10,
                   reorder::Bool = true,
@@ -73,7 +73,7 @@ function BallTree(data::Vector{V},
     BallTree(storedata ? data : similar(data, 0), hyper_spheres, indices, metric, tree_data, reorder)
 end
 
- function BallTree(data::Matrix{T},
+ function BallTree(data::AbstractMatrix{T},
                   metric::M = Euclidean();
                   leafsize::Int = 10,
                   storedata::Bool = true,

--- a/src/brute_tree.jl
+++ b/src/brute_tree.jl
@@ -9,12 +9,12 @@ end
 
 Creates a `BruteTree` from the data using the given `metric`.
 """
-function BruteTree(data::Vector{V}, metric::Metric = Euclidean();
+function BruteTree(data::AbstractVector{V}, metric::Metric = Euclidean();
                    reorder::Bool=false, leafsize::Int=0, storedata::Bool=true) where {V <: AbstractVector}
     BruteTree(storedata ? data : Vector{V}(), metric, reorder)
 end
 
-function BruteTree(data::Matrix{T}, metric::Metric = Euclidean();
+function BruteTree(data::AbstractMatrix{T}, metric::Metric = Euclidean();
                    reorder::Bool=false, leafsize::Int=0, storedata::Bool=true) where {T}
     dim = size(data, 1)
     npoints = size(data, 2)

--- a/src/datafreetree.jl
+++ b/src/datafreetree.jl
@@ -10,7 +10,7 @@ function get_points_dim(data)
     if eltype(data) <: AbstractVector
         ndim = eltype(eltype(data))
         npoints = length(data)
-    elseif typeof(data) <: Matrix
+    elseif typeof(data) <: AbstractMatrix
         ndim = size(data, 1)
         npoints = size(data, 2)
     else
@@ -39,7 +39,7 @@ end
 
 Returns the `KDTree`/`BallTree` wrapped by `datafreetree`, set up to use `data` for the points data.
 """
-function injectdata(datafreetree::DataFreeTree, data::Matrix{T}) where {T}
+function injectdata(datafreetree::DataFreeTree, data::AbstractMatrix{T}) where {T}
     dim = size(data, 1)
     npoints = size(data, 2)
     if isbitstype(T)
@@ -51,7 +51,7 @@ function injectdata(datafreetree::DataFreeTree, data::Matrix{T}) where {T}
     injectdata(datafreetree, new_data, new_hash)
 end
 
-function injectdata(datafreetree::DataFreeTree, data::Vector{V}, new_hash::UInt64=0) where {V <: AbstractVector}
+function injectdata(datafreetree::DataFreeTree, data::AbstractVector{V}, new_hash::UInt64=0) where {V <: AbstractVector}
     if new_hash == 0
         new_hash = hash(data)
     end

--- a/src/hyperrectangles.jl
+++ b/src/hyperrectangles.jl
@@ -6,7 +6,7 @@ struct HyperRectangle{T}
 end
 
 # Computes a bounding box around a point cloud
-function compute_bbox(data::Vector{V}) where {V <: AbstractVector}
+function compute_bbox(data::AbstractVector{V}) where {V <: AbstractVector}
     T = eltype(V)
     n_dim = length(V)
     maxes = Vector{T}(undef, n_dim)

--- a/src/hyperspheres.jl
+++ b/src/hyperspheres.jl
@@ -42,7 +42,7 @@ end
     return c1, false
 end
 
-function create_bsphere(data::Vector{V}, metric::Metric, indices::Vector{Int}, low, high, ab) where {V}
+function create_bsphere(data::AbstractVector{V}, metric::Metric, indices::Vector{Int}, low, high, ab) where {V}
     n_dim = size(data, 1)
     n_points = high - low + 1
     # First find center of all points

--- a/src/kd_tree.jl
+++ b/src/kd_tree.jl
@@ -24,7 +24,7 @@ end
 Creates a `KDTree` from the data using the given `metric` and `leafsize`.
 The `metric` must be a `MinkowskiMetric`.
 """
-function KDTree(data::Vector{V},
+function KDTree(data::AbstractVector{V},
                 metric::M = Euclidean();
                 leafsize::Int = 10,
                 storedata::Bool = true,
@@ -66,7 +66,7 @@ function KDTree(data::Vector{V},
     KDTree(storedata ? data : similar(data, 0), hyper_rec, indices, metric, nodes, tree_data, reorder)
 end
 
- function KDTree(data::Matrix{T},
+ function KDTree(data::AbstractMatrix{T},
                 metric::M = Euclidean();
                 leafsize::Int = 10,
                 storedata::Bool = true,
@@ -85,7 +85,7 @@ end
 end
 
 function build_KDTree(index::Int,
-                      data::Vector{V},
+                      data::AbstractVector{V},
                       data_reordered::Vector{V},
                       hyper_rec::HyperRectangle,
                       nodes::Vector{KDNode{T}},

--- a/src/tree_data.jl
+++ b/src/tree_data.jl
@@ -10,7 +10,7 @@ struct TreeData
 end
 
 
-function TreeData(data::Vector{V}, leafsize) where V
+function TreeData(data::AbstractVector{V}, leafsize) where V
     n_dim, n_p = length(V), length(data)
 
     # If number of points is zero

--- a/src/tree_ops.jl
+++ b/src/tree_ops.jl
@@ -77,7 +77,7 @@ end
 
 # Store all the points in a leaf node continuously in memory in data_reordered to improve cache locality.
 # Also stores the mapping to get the index into the original data from the reordered data.
-function reorder_data!(data_reordered::Vector{V}, data::Vector{V}, index::Int,
+function reorder_data!(data_reordered::Vector{V}, data::AbstractVector{V}, index::Int,
                          indices::Vector{Int}, indices_reordered::Vector{Int}, tree_data::TreeData) where {V}
 
     for i in get_leaf_range(tree_data, index)

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -1,5 +1,5 @@
-# Find the dimension witht the largest spread.
-function find_largest_spread(data::Vector{V}, indices, low, high) where {V}
+# Find the dimension with the largest spread.
+function find_largest_spread(data::AbstractVector{V}, indices, low, high) where {V}
     T = eltype(V)
     n_points = high - low + 1
     n_dim = length(V)
@@ -25,7 +25,7 @@ end
 # Taken from https://github.com/JuliaLang/julia/blob/v0.3.5/base/sort.jl
 # and modified to compare against a matrix
 @inline function select_spec!(v::Vector{Int}, k::Int, lo::Int,
-                              hi::Int, data::Vector, dim::Int)
+                              hi::Int, data::AbstractVector, dim::Int)
     lo <= k <= hi || error("select index $k is out of range $lo:$hi")
     @inbounds while lo < hi
         if hi - lo == 1

--- a/test/test_datafreetree.jl
+++ b/test/test_datafreetree.jl
@@ -1,25 +1,29 @@
 using Mmap
 
 @testset "datafreetree" begin
+    function test(data, data2, data3)
+        t = DataFreeTree(KDTree, data)
+        @test_throws ArgumentError injectdata(t, data2)
+        @test_throws DimensionMismatch injectdata(t, data3)
+        for typ in [KDTree, BallTree]
+            dfilename = tempname()
+            d = 2
+            n = 100
+            mktemp() do _, io
+                data = Mmap.mmap(io, Matrix{Float32}, (d, n))
+                data[:] = rand(Float32, d, n)
+                t = injectdata(DataFreeTree(typ, data), data)
+                tr = typ(data)
+                for i = 1:n
+                    @test knn(t, data[:,i], 3) == knn(tr, data[:,i], 3)
+                end
+                finalize(data)
+            end
+        end
+    end
     data = rand(2,100)
     data2 = rand(2,100)
     data3 = rand(3,100)
-    t = DataFreeTree(KDTree, data)
-    @test_throws ArgumentError injectdata(t, data2)
-    @test_throws DimensionMismatch injectdata(t, data3)
-    for typ in [KDTree, BallTree]
-        dfilename = tempname()
-        d = 2
-        n = 100
-        mktemp() do _, io
-            data = Mmap.mmap(io, Matrix{Float32}, (d, n))
-            data[:] = rand(Float32, d, n)
-            t = injectdata(DataFreeTree(typ, data), data)
-            tr = typ(data)
-            for i = 1:n
-                @test knn(t, data[:,i], 3) == knn(tr, data[:,i], 3)
-            end
-            finalize(data)
-        end
-    end
+    test(data, data2, data3)
+    test(view(data, :, :), view(data2, :, :), view(data3, :, :))
 end

--- a/test/test_inrange.jl
+++ b/test/test_inrange.jl
@@ -2,48 +2,51 @@
 @testset "inrange" begin
     @testset "metric" for metric in [Euclidean()]
         @testset "tree type" for TreeType in trees_with_brute
+            function test(data)
+                tree = TreeType(data, metric; leafsize=2)
+                dosort = true
+
+                idxs = inrange(tree, [1.1, 1.1, 1.1], 0.2, dosort)
+                @test idxs == [8] # Only corner 8 at least 0.2 distance away from [1.1, 1.1, 1.1]
+
+                idxs = inrange(tree, [0.0, 0.0, 0.5], 0.6, dosort)
+                @test idxs == [1, 2] # Corner 1 and 2 at least 0.6 distance away from [0.0, 0.0, 0.5]
+
+                idxs = inrange(tree, [0, 0, 0], 0.6, dosort)
+                @test idxs == [1]
+
+                X = [0.0 0.0; 0.0 0.0; 0.5 0.0]
+                idxs1 = inrange(tree, X, 0.6, dosort)
+                idxs2 = inrange(tree, view(X,:,1:2), 0.6, dosort)
+                @test idxs1 == idxs2
+                @test idxs1[1] == [1,2]
+                @test idxs1[2] == [1]
+
+                idxs = inrange(tree, [SVector{3,Float64}(0.0, 0.0, 0.5), SVector{3,Float64}(0.0, 0.0, 0.0)], 0.6, dosort)
+                @test idxs[1] == [1,2]
+                @test idxs[2] == [1]
+
+                idxs = inrange(tree, [0.33333333333, 0.33333333333, 0.33333333333], 1, dosort)
+                @test idxs == [1, 2, 3, 5]
+
+                idxs = inrange(tree, [0.5, 0.5, 0.5], 0.2, dosort)
+                @test idxs == []
+
+                idxs = inrange(tree, [0.5, 0.5, 0.5], 1.0, dosort)
+                @test idxs == [1, 2, 3, 4, 5, 6, 7, 8]
+
+                @test_throws ArgumentError inrange(tree, rand(3), -0.1)
+                @test_throws ArgumentError inrange(tree, rand(5), 1.0)
+
+                empty_tree = TreeType(rand(3,0), metric)
+                idxs = inrange(empty_tree, [0.5, 0.5, 0.5], 1.0)
+                @test idxs == []
+            end
             data = [0.0 0.0 0.0 0.0 1.0 1.0 1.0 1.0;
                     0.0 0.0 1.0 1.0 0.0 0.0 1.0 1.0;
                     0.0 1.0 0.0 1.0 0.0 1.0 0.0 1.0] # 8 node cube
-
-            tree = TreeType(data, metric; leafsize=2)
-            dosort = true
-
-            idxs = inrange(tree, [1.1, 1.1, 1.1], 0.2, dosort)
-            @test idxs == [8] # Only corner 8 at least 0.2 distance away from [1.1, 1.1, 1.1]
-
-            idxs = inrange(tree, [0.0, 0.0, 0.5], 0.6, dosort)
-            @test idxs == [1, 2] # Corner 1 and 2 at least 0.6 distance away from [0.0, 0.0, 0.5]
-
-            idxs = inrange(tree, [0, 0, 0], 0.6, dosort)
-            @test idxs == [1]
-
-            X = [0.0 0.0; 0.0 0.0; 0.5 0.0]
-            idxs1 = inrange(tree, X, 0.6, dosort)
-            idxs2 = inrange(tree, view(X,:,1:2), 0.6, dosort)
-            @test idxs1 == idxs2
-            @test idxs1[1] == [1,2]
-            @test idxs1[2] == [1]
-
-            idxs = inrange(tree, [SVector{3,Float64}(0.0, 0.0, 0.5), SVector{3,Float64}(0.0, 0.0, 0.0)], 0.6, dosort)
-            @test idxs[1] == [1,2]
-            @test idxs[2] == [1]
-
-            idxs = inrange(tree, [0.33333333333, 0.33333333333, 0.33333333333], 1, dosort)
-            @test idxs == [1, 2, 3, 5]
-
-            idxs = inrange(tree, [0.5, 0.5, 0.5], 0.2, dosort)
-            @test idxs == []
-
-            idxs = inrange(tree, [0.5, 0.5, 0.5], 1.0, dosort)
-            @test idxs == [1, 2, 3, 4, 5, 6, 7, 8]
-
-            @test_throws ArgumentError inrange(tree, rand(3), -0.1)
-            @test_throws ArgumentError inrange(tree, rand(5), 1.0)
-
-            empty_tree = TreeType(rand(3,0), metric)
-            idxs = inrange(empty_tree, [0.5, 0.5, 0.5], 1.0)
-            @test idxs == []
+            test(data)
+            test(view(data, :, :))
         end
     end
 end

--- a/test/test_knn.jl
+++ b/test/test_knn.jl
@@ -5,43 +5,46 @@ import Distances.evaluate
 @testset "knn" begin
     @testset "metric" for metric in metrics
         @testset "tree type" for TreeType in trees_with_brute
+            function test(data)
+                tree = TreeType(data, metric; leafsize=2)
+
+                idxs, dists = knn(tree, [0.8, 0.8], 1)
+                @test idxs[1] == 8 # Should be closest to top right corner
+                @test evaluate(metric, [0.2, 0.2], zeros(2)) ≈ dists[1]
+
+                idxs, dists = knn(tree, [0.1, 0.8], 3, true)
+                @test idxs == [3, 2, 5]
+
+                X = [0.8 0.1; 0.8 0.8]
+                idxs1, dists1 = knn(tree, X, 1, true)
+                idxs2, dists2 = knn(tree, view(X,:,1:2), 1, true)
+                @test idxs1 == idxs2
+                @test dists1 == dists2
+                @test idxs1[1][1] == 8
+                @test idxs1[2][1] == 3
+
+                idxs, dists = knn(tree, [SVector{2, Float64}(0.8,0.8), SVector{2, Float64}(0.1,0.8)], 1, true)
+                @test idxs[1][1] == 8
+                @test idxs[2][1] == 3
+
+                idxs, dists = knn(tree, [1//10, 8//10], 3, true)
+                @test idxs == [3, 2, 5]
+
+                @test_throws ArgumentError knn(tree, [0.1, 0.8], -1) # k < 0
+                @test_throws ArgumentError knn(tree, [0.1, 0.8], 10) # k > n_points
+                @test_throws ArgumentError knn(tree, [0.1], 10) # n_dim != trees dim
+
+                empty_tree = TreeType(rand(2,0), metric; leafsize=2)
+                idxs, dists = knn(empty_tree, [0.5, 0.5], 0, true)
+                @test idxs == Int[]
+                @test_throws ArgumentError knn(empty_tree, [0.1, 0.8], -1) # k < 0
+                @test_throws ArgumentError knn(empty_tree, [0.1, 0.8], 1)  # k > n_points
+            end
             # 8 node rectangle
             data = [0.0 0.0 0.0 0.5 0.5 1.0 1.0 1.0;
                     0.0 0.5 1.0 0.0 1.0 0.0 0.5 1.0]
-
-            tree = TreeType(data, metric; leafsize=2)
-
-            idxs, dists = knn(tree, [0.8, 0.8], 1)
-            @test idxs[1] == 8 # Should be closest to top right corner
-            @test evaluate(metric, [0.2, 0.2], zeros(2)) ≈ dists[1]
-
-            idxs, dists = knn(tree, [0.1, 0.8], 3, true)
-            @test idxs == [3, 2, 5]
-
-            X = [0.8 0.1; 0.8 0.8]
-            idxs1, dists1 = knn(tree, X, 1, true)
-            idxs2, dists2 = knn(tree, view(X,:,1:2), 1, true)
-            @test idxs1 == idxs2
-            @test dists1 == dists2
-            @test idxs1[1][1] == 8
-            @test idxs1[2][1] == 3
-
-            idxs, dists = knn(tree, [SVector{2, Float64}(0.8,0.8), SVector{2, Float64}(0.1,0.8)], 1, true)
-            @test idxs[1][1] == 8
-            @test idxs[2][1] == 3
-
-            idxs, dists = knn(tree, [1//10, 8//10], 3, true)
-            @test idxs == [3, 2, 5]
-
-            @test_throws ArgumentError knn(tree, [0.1, 0.8], -1) # k < 0
-            @test_throws ArgumentError knn(tree, [0.1, 0.8], 10) # k > n_points
-            @test_throws ArgumentError knn(tree, [0.1], 10) # n_dim != trees dim
-
-            empty_tree = TreeType(rand(2,0), metric; leafsize=2)
-            idxs, dists = knn(empty_tree, [0.5, 0.5], 0, true)
-            @test idxs == Int[]
-            @test_throws ArgumentError knn(empty_tree, [0.1, 0.8], -1) # k < 0
-            @test_throws ArgumentError knn(empty_tree, [0.1, 0.8], 1)  # k > n_points
+            test(data)
+            test(view(data, :, :))
         end
     end
 end
@@ -49,13 +52,18 @@ end
 @testset "knn skip" begin
     @testset "tree type" for TreeType in trees_with_brute
         data = rand(2, 1000)
-        tree = TreeType(data)
+        function test(data)
+            tree = TreeType(data)
 
-        idxs, dists = knn(tree, data[:, 10], 2, true)
-        first_idx = idxs[1]
-        second_idx = idxs[2]
+            idxs, dists = knn(tree, data[:, 10], 2, true)
+            first_idx = idxs[1]
+            second_idx = idxs[2]
 
-        idxs, dists = knn(tree, data[:, 10], 2, true, i -> i == first_idx)
-        @test idxs[1] == second_idx
+            idxs, dists = knn(tree, data[:, 10], 2, true, i -> i == first_idx)
+            @test idxs[1] == second_idx
+        end
+        data = rand(2, 1000)
+        test(data)
+        test(view(data, :, :))
     end
 end


### PR DESCRIPTION
Since data is eventually copied as an `Array` when reordered, there is no need to restrict it to be an `Array`. By allowing it to be an `AbstractArray` we can do things like `KDTree(view(pointcloud, 10:50))`, which is a great way to find neighbors within a subset of a pointcloud. As far as I can see, there is no performance penalty from this.

NOTE: I thought about the possibility of extending the definition of `struct`s to also allow store data to be more general than `Array` without copying it (as would be needed when we do, say, `KDTree(data, reorder = false)`), but it seems this possibility (`reorder = false`) is not part of the API, so this should never be necessary.