### PR TITLE
Necessary adaption of evaluation to parameter trait for UnionMetrics in Distances.jl

### DIFF
--- a/src/NearestNeighbors.jl
+++ b/src/NearestNeighbors.jl
@@ -1,7 +1,7 @@
 module NearestNeighbors
 
 using Distances
-import Distances: Metric, result_type, eval_reduce, eval_end, eval_op, eval_start, evaluate
+import Distances: Metric, result_type, eval_reduce, eval_end, eval_op, eval_start, evaluate, parameters
 
 using StaticArrays
 import Base.show

--- a/src/ball_tree.jl
+++ b/src/ball_tree.jl
@@ -59,6 +59,14 @@ function BallTree(data::AbstractVector{V},
         data_reordered = Vector{V}()
     end
 
+    if metric isa Distances.UnionMetrics
+        p = parameters(metric)
+        if p !== nothing && length(p) != length(V)
+            throw(ArgumentError(
+                "dimension of input points:$(length(V)) and metric parameter:$(length(p)) must agree"))
+        end
+    end
+    
     if n_p > 0
         # Call the recursive BallTree builder
         build_BallTree(1, data, data_reordered, hyper_spheres, metric, indices, indices_reordered,

--- a/src/brute_tree.jl
+++ b/src/brute_tree.jl
@@ -11,6 +11,14 @@ Creates a `BruteTree` from the data using the given `metric`.
 """
 function BruteTree(data::AbstractVector{V}, metric::Metric = Euclidean();
                    reorder::Bool=false, leafsize::Int=0, storedata::Bool=true) where {V <: AbstractVector}
+    if metric isa Distances.UnionMetrics
+        p = parameters(metric)
+        if p !== nothing && length(p) != length(V)
+           throw(ArgumentError(
+               "dimension of input points:$(length(V)) and metric parameter:$(length(p)) must agree"))
+        end
+    end
+
     BruteTree(storedata ? data : Vector{V}(), metric, reorder)
 end
 

--- a/src/evaluation.jl
+++ b/src/evaluation.jl
@@ -8,9 +8,6 @@
 function Distances.evaluate(d::Distances.UnionMetrics, a::AbstractVector,
                             b::AbstractVector, do_end::Bool)
     p = Distances.parameters(d)
-    if p !== nothing
-        length(p) == length(b) || throw(DimensionMismatch())
-    end
     s = eval_start(d, a, b)
     if p === nothing
         @simd for i in eachindex(b)

--- a/src/evaluation.jl
+++ b/src/evaluation.jl
@@ -8,6 +8,9 @@
 function Distances.evaluate(d::Distances.UnionMetrics, a::AbstractVector,
                             b::AbstractVector, do_end::Bool)
     p = Distances.parameters(d)
+    if p !== nothing
+        length(p) == length(b) || throw(DimensionMismatch())
+    end
     s = eval_start(d, a, b)
     if p === nothing
         @simd for i in eachindex(b)

--- a/src/kd_tree.jl
+++ b/src/kd_tree.jl
@@ -63,6 +63,14 @@ function KDTree(data::AbstractVector{V},
         indices = indices_reordered
     end
 
+    if metric isa Distances.UnionMetrics
+        p = parameters(metric)
+        if p !== nothing && length(p) != length(V)
+            throw(ArgumentError(
+                "dimension of input points:$(length(V)) and metric parameter:$(length(p)) must agree"))
+        end
+    end
+    
     KDTree(storedata ? data : similar(data, 0), hyper_rec, indices, metric, nodes, tree_data, reorder)
 end
 


### PR DESCRIPTION
Once https://github.com/JuliaStats/Distances.jl/pull/150 is merged, all `UnionMetrics` will have a `parameters` trait, most of which have `nothing`, but some do have an array with weights or periods. This requires some adaptation in the `evaluation.jl` code here.