### PR TITLE
ensure specialization on the skip function

### DIFF
--- a/src/ball_tree.jl
+++ b/src/ball_tree.jl
@@ -150,9 +150,9 @@ end
 
 function _knn(tree::BallTree,
               point::AbstractVector,
-              best_idxs::Vector{Int},
-              best_dists::Vector,
-              skip::Function)
+              best_idxs::AbstractVector{Int},
+              best_dists::AbstractVector,
+              skip::F) where {F}
     knn_kernel!(tree, 1, point, best_idxs, best_dists, skip)
     return
 end
@@ -161,8 +161,8 @@ end
 function knn_kernel!(tree::BallTree{V},
                            index::Int,
                            point::AbstractArray,
-                           best_idxs::Vector{Int},
-                           best_dists::Vector,
+                           best_idxs::AbstractVector{Int},
+                           best_dists::AbstractVector,
                            skip::F) where {V, F}
     if isleaf(tree.tree_data.n_internal_nodes, index)
         add_points_knn!(best_dists, best_idxs, tree, index, point, true, skip)

--- a/src/brute_tree.jl
+++ b/src/brute_tree.jl
@@ -32,9 +32,9 @@ end
 
 function _knn(tree::BruteTree{V},
                  point::AbstractVector,
-                 best_idxs::Vector{Int},
-                 best_dists::Vector,
-                 skip::Function) where {V}
+                 best_idxs::AbstractVector{Int},
+                 best_dists::AbstractVector,
+                 skip::F) where {V, F}
 
     knn_kernel!(tree, point, best_idxs, best_dists, skip)
     return
@@ -42,8 +42,8 @@ end
 
 function knn_kernel!(tree::BruteTree{V},
                      point::AbstractVector,
-                     best_idxs::Vector{Int},
-                     best_dists::Vector,
+                     best_idxs::AbstractVector{Int},
+                     best_dists::AbstractVector,
                      skip::F) where {V, F}
     for i in 1:length(tree.data)
         if skip(i)

--- a/src/kd_tree.jl
+++ b/src/kd_tree.jl
@@ -158,23 +158,21 @@ end
 
 function _knn(tree::KDTree,
               point::AbstractVector,
-              best_idxs::Vector{Int},
-              best_dists::Vector,
-              skip::Function)
-
+              best_idxs::AbstractVector{Int},
+              best_dists::AbstractVector,
+              skip::F) where {F}
     init_min = get_min_distance(tree.hyper_rec, point)
     knn_kernel!(tree, 1, point, best_idxs, best_dists, init_min, skip)
     @simd for i in eachindex(best_dists)
         @inbounds best_dists[i] = eval_end(tree.metric, best_dists[i])
     end
-    return
 end
 
 function knn_kernel!(tree::KDTree{V},
                         index::Int,
                         point::AbstractVector,
-                        best_idxs::Vector{Int},
-                        best_dists::Vector,
+                        best_idxs::AbstractVector{Int},
+                        best_dists::AbstractVector,
                         min_dist,
                         skip::F) where {V, F}
     # At a leaf node. Go through all points in node and add those in range

--- a/src/knn.jl
+++ b/src/knn.jl
@@ -14,7 +14,7 @@ in the order of increasing distance to the point. `skip` is an optional predicat
 to determine if a point that would be returned should be skipped based on its 
 index.
 """
-function knn(tree::NNTree{V}, points::Vector{T}, k::Int, sortres=false, skip::Function=always_false) where {V, T <: AbstractVector}
+function knn(tree::NNTree{V}, points::Vector{T}, k::Int, sortres=false, skip::F=always_false) where {V, T <: AbstractVector, F<:Function}
     check_input(tree, points)
     check_k(tree, k)
     n_points = length(points)
@@ -26,7 +26,7 @@ function knn(tree::NNTree{V}, points::Vector{T}, k::Int, sortres=false, skip::Fu
     return idxs, dists
 end
 
-function knn_point!(tree::NNTree{V}, point::AbstractVector{T}, sortres, dist, idx, skip) where {V, T <: Number}
+function knn_point!(tree::NNTree{V}, point::AbstractVector{T}, sortres, dist, idx, skip::F) where {V, T <: Number, F}
     fill!(idx, -1)
     fill!(dist, typemax(get_T(eltype(V))))
     _knn(tree, point, idx, dist, skip)
@@ -36,9 +36,10 @@ function knn_point!(tree::NNTree{V}, point::AbstractVector{T}, sortres, dist, id
             @inbounds idx[j] = tree.indices[idx[j]]
         end
     end
+    return
 end
 
-function knn(tree::NNTree{V}, point::AbstractVector{T}, k::Int, sortres=false, skip::Function=always_false) where {V, T <: Number}
+function knn(tree::NNTree{V}, point::AbstractVector{T}, k::Int, sortres=false, skip::F=always_false) where {V, T <: Number, F<:Function}
     check_k(tree, k)
     idx = Vector{Int}(undef, k)
     dist = Vector{get_T(eltype(V))}(undef, k)
@@ -46,7 +47,7 @@ function knn(tree::NNTree{V}, point::AbstractVector{T}, k::Int, sortres=false, s
     return idx, dist
 end
 
-function knn(tree::NNTree{V}, point::AbstractMatrix{T}, k::Int, sortres=false, skip::Function=always_false) where {V, T <: Number}
+function knn(tree::NNTree{V}, point::AbstractMatrix{T}, k::Int, sortres=false, skip::F=always_false) where {V, T <: Number, F<:Function}
     dim = size(point, 1)
     npoints = size(point, 2)
     if isbitstype(T)
@@ -57,9 +58,9 @@ function knn(tree::NNTree{V}, point::AbstractMatrix{T}, k::Int, sortres=false, s
     knn(tree, new_data, k, sortres, skip)
 end
 
-nn(tree::NNTree{V}, points::AbstractVector{T}, skip::Function=always_false) where {V, T <: Number}         = _nn(tree, points, skip) .|> first
-nn(tree::NNTree{V}, points::AbstractVector{T}, skip::Function=always_false) where {V, T <: AbstractVector} = _nn(tree, points, skip)  |> _firsteach
-nn(tree::NNTree{V}, points::AbstractMatrix{T}, skip::Function=always_false) where {V, T <: Number}         = _nn(tree, points, skip)  |> _firsteach
+nn(tree::NNTree{V}, points::AbstractVector{T}, skip::F=always_false) where {V, T <: Number,         F <: Function} = _nn(tree, points, skip) .|> first
+nn(tree::NNTree{V}, points::AbstractVector{T}, skip::F=always_false) where {V, T <: AbstractVector, F <: Function} = _nn(tree, points, skip)  |> _firsteach
+nn(tree::NNTree{V}, points::AbstractMatrix{T}, skip::F=always_false) where {V, T <: Number,         F <: Function} = _nn(tree, points, skip)  |> _firsteach
 
 _nn(tree, points, skip) = knn(tree, points, 1, false, skip)
 

--- a/src/tree_ops.jl
+++ b/src/tree_ops.jl
@@ -90,7 +90,7 @@ end
 
 # Checks the distance function and add those points that are among the k best.
 # Uses a heap for fast insertion.
-@inline function add_points_knn!(best_dists::Vector, best_idxs::Vector{Int},
+@inline function add_points_knn!(best_dists::AbstractVector, best_idxs::AbstractVector{Int},
                                  tree::NNTree, index::Int, point::AbstractVector,
                                  do_end::Bool, skip::F) where {F}
     for z in get_leaf_range(tree.tree_data, index)
@@ -114,7 +114,7 @@ end
 # stop computing the distance function as soon as we reach the desired radius.
 # This will probably prevent SIMD and other optimizations so some care is needed
 # to evaluate if it is worth it.
-@inline function add_points_inrange!(idx_in_ball::Vector{Int}, tree::NNTree,
+@inline function add_points_inrange!(idx_in_ball::AbstractVector{Int}, tree::NNTree,
                                      index::Int, point::AbstractVector, r::Number, do_end::Bool)
     for z in get_leaf_range(tree.tree_data, index)
         idx = tree.reordered ? z : tree.indices[z]


### PR DESCRIPTION
Removes some unwanted nonspecialization.

Benchmark:

```julia
dim = 3;
n_points = 10^6;
X = rand(dim, n_points);
k = 10;
using NearestNeighbors;
@time kd_tree = KDTree(X);
@btime knn(kd_tree, X, k);
```

PR:
```julia
julia> @btime knn(kd_tree, X, k);
  2.645 s (2000008 allocations: 343.32 MiB)
```

Master
```julia
 julia> @btime knn(kd_tree, X, k);
  2.867 s (5000009 allocations: 511.17 MiB)
```

Note especially the allocations.