### PR TITLE
Add `inrangecount` for efficient counting of neighbors

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,6 @@ point = rand(3)
 balltree = BallTree(data)
 idxs = inrange(balltree, point, r, true)
 
-
 # 4-element Array{Int64,1}:
 #  317
 #  983

--- a/README.md
+++ b/README.md
@@ -157,11 +157,14 @@ point = rand(3)
 balltree = BallTree(data)
 idxs = inrange(balltree, point, r, true)
 
+
 # 4-element Array{Int64,1}:
 #  317
 #  983
 # 4577
 # 8675
+
+neighborscount = inrangecount(balltree, point, r, true) # if you were just interested in the number of points, this function will count them without allocating arrays for the indexes
 ```
 
 ## Using on-disk data sets

--- a/src/NearestNeighbors.jl
+++ b/src/NearestNeighbors.jl
@@ -7,7 +7,7 @@ using StaticArrays
 import Base.show
 
 export NNTree, BruteTree, KDTree, BallTree, DataFreeTree
-export knn, nn, inrange # TODOs? , allpairs, distmat, npairs
+export knn, nn, inrange, inrangecount # TODOs? , allpairs, distmat, npairs
 export injectdata
 
 export Euclidean,

--- a/src/ball_tree.jl
+++ b/src/ball_tree.jl
@@ -99,6 +99,15 @@ function BallTree(data::AbstractVecOrMat{T},
             reorderbuffer = reorderbuffer_points)
 end
 
+function BallTree(data::Vector{T},
+                  metric::M = Euclidean();
+                  leafsize::Int = 10,
+                  storedata::Bool = true,
+                  reorder::Bool = true,
+                  reorderbuffer::Vector{T} = Vector{T}(undef, 0, 0)) where {T <: AbstractFloat, M <: Metric}
+    BallTree(hcat(data), metric, leafsize = leafsize, storedata = storedata, reorder = reorder, reorderbuffer = reorderbuffer);
+end
+
 # Recursive function to build the tree.
 function build_BallTree(index::Int,
                         data::Vector{V},

--- a/src/ball_tree.jl
+++ b/src/ball_tree.jl
@@ -105,7 +105,8 @@ function BallTree(data::Vector{T},
                   storedata::Bool = true,
                   reorder::Bool = true,
                   reorderbuffer::Vector{T} = Vector{T}(undef, 0, 0)) where {T <: AbstractFloat, M <: Metric}
-    BallTree(hcat(data), metric, leafsize = leafsize, storedata = storedata, reorder = reorder, reorderbuffer = reorderbuffer);
+    BallTree(reshape(data, length(data), 1), metric, leafsize = leafsize,
+             storedata = storedata, reorder = reorder, reorderbuffer = reorderbuffer);
 end
 
 # Recursive function to build the tree.

--- a/src/ball_tree.jl
+++ b/src/ball_tree.jl
@@ -99,16 +99,6 @@ function BallTree(data::AbstractVecOrMat{T},
             reorderbuffer = reorderbuffer_points)
 end
 
-function BallTree(data::Vector{T},
-                  metric::M = Euclidean();
-                  leafsize::Int = 10,
-                  storedata::Bool = true,
-                  reorder::Bool = true,
-                  reorderbuffer::Vector{T} = Vector{T}(undef, 0, 0)) where {T <: AbstractFloat, M <: Metric}
-    BallTree(reshape(data, length(data), 1), metric, leafsize = leafsize,
-             storedata = storedata, reorder = reorder, reorderbuffer = reorderbuffer);
-end
-
 # Recursive function to build the tree.
 function build_BallTree(index::Int,
                         data::Vector{V},

--- a/src/brute_tree.jl
+++ b/src/brute_tree.jl
@@ -32,7 +32,7 @@ end
 
 function BruteTree(data::Vector{T}, metric::Metric = Euclidean();
                    reorder::Bool=false, leafsize::Int=0, storedata::Bool=true) where {T}
-    BruteTree(hcat(data),
+    BruteTree(reshape(data, length(data), 1),
               metric, reorder = reorder, leafsize = leafsize, storedata = storedata));
 end
 

--- a/src/brute_tree.jl
+++ b/src/brute_tree.jl
@@ -62,20 +62,22 @@ end
 function _inrange(tree::BruteTree,
                   point::AbstractVector,
                   radius::Number,
-                  idx_in_ball::Vector{Int})
-    inrange_kernel!(tree, point, radius, idx_in_ball)
-    return
+                  idx_in_ball::Union{Nothing, Vector{Int}})
+    return inrange_kernel!(tree, point, radius, idx_in_ball)
 end
 
 
 function inrange_kernel!(tree::BruteTree,
                          point::AbstractVector,
                          r::Number,
-                         idx_in_ball::Vector{Int})
+                         idx_in_ball::Union{Nothing, Vector{Int}})
+    count = 0
     for i in 1:length(tree.data)
         d = evaluate(tree.metric, tree.data[i], point)
         if d <= r
-            push!(idx_in_ball, i)
+            count += 1
+            idx_in_ball !== nothing && push!(idx_in_ball, i)
         end
     end
+    return count
 end

--- a/src/brute_tree.jl
+++ b/src/brute_tree.jl
@@ -33,7 +33,7 @@ end
 function BruteTree(data::Vector{T}, metric::Metric = Euclidean();
                    reorder::Bool=false, leafsize::Int=0, storedata::Bool=true) where {T}
     BruteTree(reshape(data, length(data), 1),
-              metric, reorder = reorder, leafsize = leafsize, storedata = storedata));
+              metric, reorder = reorder, leafsize = leafsize, storedata = storedata);
 end
 
 function _knn(tree::BruteTree{V},

--- a/src/brute_tree.jl
+++ b/src/brute_tree.jl
@@ -30,6 +30,12 @@ function BruteTree(data::AbstractVecOrMat{T}, metric::Metric = Euclidean();
               metric, reorder = reorder, leafsize = leafsize, storedata = storedata)
 end
 
+function BruteTree(data::Vector{T}, metric::Metric = Euclidean();
+                   reorder::Bool=false, leafsize::Int=0, storedata::Bool=true) where {T}
+    BruteTree(hcat(data),
+              metric, reorder = reorder, leafsize = leafsize, storedata = storedata));
+end
+
 function _knn(tree::BruteTree{V},
                  point::AbstractVector,
                  best_idxs::AbstractVector{Int},

--- a/src/brute_tree.jl
+++ b/src/brute_tree.jl
@@ -30,12 +30,6 @@ function BruteTree(data::AbstractVecOrMat{T}, metric::Metric = Euclidean();
               metric, reorder = reorder, leafsize = leafsize, storedata = storedata)
 end
 
-function BruteTree(data::Vector{T}, metric::Metric = Euclidean();
-                   reorder::Bool=false, leafsize::Int=0, storedata::Bool=true) where {T}
-    BruteTree(reshape(data, length(data), 1),
-              metric, reorder = reorder, leafsize = leafsize, storedata = storedata);
-end
-
 function _knn(tree::BruteTree{V},
                  point::AbstractVector,
                  best_idxs::AbstractVector{Int},

--- a/src/inrange.jl
+++ b/src/inrange.jl
@@ -56,7 +56,7 @@ end
 """
     inrangecount(tree::NNTree, points, radius) -> count
 
-Count all the points in the tree which is closer than `radius` to `points`.
+Count all the points in the tree which are closer than `radius` to `points`.
 """
 function inrangecount(tree::NNTree{V}, point::AbstractVector{T}, radius::Number) where {V, T <: Number}
     check_input(tree, point)

--- a/src/inrange.jl
+++ b/src/inrange.jl
@@ -58,10 +58,10 @@ function inrangecount(tree::NNTree,
     check_radius(radius)
 
     idxs = Vector{Int}()
-    counts = Vector{Int}()
+    counts = Vector{Int}(undef, length(points))
     for i in 1:length(points)
         inrange_point!(tree, points[i], radius, false, idxs)
-        counts = length(idxs)
+        counts[i] = length(idxs)
         empty!(idxs)
     end
     return counts

--- a/src/inrange.jl
+++ b/src/inrange.jl
@@ -50,3 +50,30 @@ function inrange(tree::NNTree{V}, point::AbstractMatrix{T}, radius::Number, sort
     end
     inrange(tree, new_data, radius, sortres)
 end
+
+function inrangecount(tree::NNTree,
+                      points::Vector{T},
+                      radius::Number) where {T <: AbstractVector}
+    check_input(tree, points)
+    check_radius(radius)
+
+    idxs = Vector{Int}()
+    counts = Vector{Int}()
+    for i in 1:length(points)
+        inrange_point!(tree, points[i], radius, false, idxs)
+        counts = length(idxs)
+        empty!(idxs)
+    end
+    return counts
+end
+
+function inrangecount(tree::NNTree{V}, point::AbstractMatrix{T}, radius::Number) where {V, T <: Number}
+    dim = size(point, 1)
+    npoints = size(point, 2)
+    if isbitstype(T)
+        new_data = copy_svec(T, point, Val(dim))
+    else
+        new_data = SVector{dim,T}[SVector{dim,T}(point[:, i]) for i in 1:npoints]
+    end
+    inrangecount(tree, new_data, radius)
+end

--- a/src/kd_tree.jl
+++ b/src/kd_tree.jl
@@ -100,6 +100,16 @@ end
            reorderbuffer = reorderbuffer_points)
 end
 
+function KDTree(data::Vector{T},
+                metric::M = Euclidean();
+                leafsize::Int = 10,
+                storedata::Bool = true,
+                reorder::Bool = true,
+                reorderbuffer::Vector{T} = Vector{T}(undef, 0, 0)) where {T <: AbstractFloat, M <: MinkowskiMetric}
+   KDTree(hcat(data), metric, leafsize = leafsize, storedata = storedata, reorder = reorder,
+           reorderbuffer = reorderbuffer_points)
+end
+
 function build_KDTree(index::Int,
                       data::AbstractVector{V},
                       data_reordered::Vector{V},

--- a/src/kd_tree.jl
+++ b/src/kd_tree.jl
@@ -106,8 +106,8 @@ function KDTree(data::Vector{T},
                 storedata::Bool = true,
                 reorder::Bool = true,
                 reorderbuffer::Vector{T} = Vector{T}(undef, 0, 0)) where {T <: AbstractFloat, M <: MinkowskiMetric}
-   KDTree(hcat(data), metric, leafsize = leafsize, storedata = storedata, reorder = reorder,
-           reorderbuffer = reorderbuffer_points)
+   KDTree(reshape(data, length(data), 1), metric, leafsize = leafsize, storedata = storedata,
+          reorder = reorder, reorderbuffer = reorderbuffer_points)
 end
 
 function build_KDTree(index::Int,

--- a/src/kd_tree.jl
+++ b/src/kd_tree.jl
@@ -100,16 +100,6 @@ end
            reorderbuffer = reorderbuffer_points)
 end
 
-function KDTree(data::Vector{T},
-                metric::M = Euclidean();
-                leafsize::Int = 10,
-                storedata::Bool = true,
-                reorder::Bool = true,
-                reorderbuffer::Vector{T} = Vector{T}(undef, 0, 0)) where {T <: AbstractFloat, M <: MinkowskiMetric}
-   KDTree(reshape(data, length(data), 1), metric, leafsize = leafsize, storedata = storedata,
-          reorder = reorder, reorderbuffer = reorderbuffer_points)
-end
-
 function build_KDTree(index::Int,
                       data::AbstractVector{V},
                       data_reordered::Vector{V},

--- a/test/test_inrange.jl
+++ b/test/test_inrange.jl
@@ -8,12 +8,18 @@
 
                 idxs = inrange(tree, [1.1, 1.1, 1.1], 0.2, dosort)
                 @test idxs == [8] # Only corner 8 at least 0.2 distance away from [1.1, 1.1, 1.1]
+                counts = inrangecount(tree, [1.1, 1.1, 1.1], 0.2)
+                @test counts == 1
 
                 idxs = inrange(tree, [0.0, 0.0, 0.5], 0.6, dosort)
                 @test idxs == [1, 2] # Corner 1 and 2 at least 0.6 distance away from [0.0, 0.0, 0.5]
+                counts = inrangecount(tree, [0.0, 0.0, 0.5], 0.6)
+                @test counts == 2
 
                 idxs = inrange(tree, [0, 0, 0], 0.6, dosort)
                 @test idxs == [1]
+                counts = inrangecount(tree, [0, 0, 0], 0.6)
+                @test counts == 1
 
                 X = [0.0 0.0; 0.0 0.0; 0.5 0.0]
                 idxs1 = inrange(tree, X, 0.6, dosort)
@@ -21,19 +27,31 @@
                 @test idxs1 == idxs2
                 @test idxs1[1] == [1,2]
                 @test idxs1[2] == [1]
+                counts1 = inrangecount(tree, X, 0.6)
+                counts2 = inrangecount(tree, view(X,:,1:2), 0.6)
+                @test counts1 == counts2
+                @test counts1 == [2, 1]
 
                 idxs = inrange(tree, [SVector{3,Float64}(0.0, 0.0, 0.5), SVector{3,Float64}(0.0, 0.0, 0.0)], 0.6, dosort)
                 @test idxs[1] == [1,2]
                 @test idxs[2] == [1]
+                counts = inrangecount(tree, [SVector{3,Float64}(0.0, 0.0, 0.5), SVector{3,Float64}(0.0, 0.0, 0.0)], 0.6)
+                @test counts == [2, 1]
 
                 idxs = inrange(tree, [0.33333333333, 0.33333333333, 0.33333333333], 1, dosort)
                 @test idxs == [1, 2, 3, 5]
+                counts = inrangecount(tree, [0.33333333333, 0.33333333333, 0.33333333333], 1)
+                @test counts == 4
 
                 idxs = inrange(tree, [0.5, 0.5, 0.5], 0.2, dosort)
                 @test idxs == []
+                counts = inrangecount(tree, [0.5, 0.5, 0.5], 0.2)
+                @test counts == 0
 
                 idxs = inrange(tree, [0.5, 0.5, 0.5], 1.0, dosort)
                 @test idxs == [1, 2, 3, 4, 5, 6, 7, 8]
+                counts = inrangecount(tree, [0.5, 0.5, 0.5], 1.0)
+                @test counts == 8
 
                 @test_throws ArgumentError inrange(tree, rand(3), -0.1)
                 @test_throws ArgumentError inrange(tree, rand(5), 1.0)
@@ -41,10 +59,14 @@
                 empty_tree = TreeType(rand(3,0), metric)
                 idxs = inrange(empty_tree, [0.5, 0.5, 0.5], 1.0)
                 @test idxs == []
+                counts = inrangecount(empty_tree, [0.5, 0.5, 0.5], 1.0)
+                @test counts == 0
 
                 one_point_tree = TreeType([0.5, 0.5, 0.5], metric)
                 idxs = inrange(one_point_tree, data, 1.0)
                 @test idxs == repeat([[1]], size(data, 2))
+                counts = inrangecount(one_point_tree, data, 1.0)
+                @test counts == repeat([1], size(data, 2))
             end
             data = [0.0 0.0 0.0 0.0 1.0 1.0 1.0 1.0;
                     0.0 0.0 1.0 1.0 0.0 0.0 1.0 1.0;


### PR DESCRIPTION
Added an efficient method for counting neighbors without storing their indexes.

**EDIT: This is out of date, see post below**

This was primarily achieved by reusing the index-accumulating vector for `inrange_points!`

```
@btime [(inrangecount(ctrees[j], (@view c.coordinates[:, c.abovethreshold]), r) .- k) ./ r ^ 2 for r ∈ radiussteps]
  72.972 ms (701 allocations: 1.76 MiB)

@btime [(length.(inrange(ctrees[j], (@view c.coordinates[:, c.abovethreshold]), r)) .- k) ./ r ^ 2 for r ∈ radiussteps]
  190.149 ms (30129 allocations: 163.86 MiB)
```

The above calculates a density gradient around each point, with 100 test points and 25 radius steps against a tree of ~20,000.

This PR cuts execution time of the above code by 2.6x, allocations by 28.7x, and allocation amount by 93.1x.

An important feature of this PR is it scales well to more test points. This implementation allowed ~20,000 points to be processed against ~20,000 points in 12 s on my machine. The previous version took 3 min. And I need it to work on hundreds of thousands or millions of points.

I'll add tests and documentation if you agree with it.