### PR TITLE
Initialize indices with `1`, allows for Infs and NaNs in the data

### DIFF
--- a/src/knn.jl
+++ b/src/knn.jl
@@ -11,7 +11,7 @@ end
 Performs a lookup of the `k` nearest neigbours to the `points` from the data
 in the `tree`. If `sortres = true` the result is sorted such that the results are
 in the order of increasing distance to the point. `skip` is an optional predicate
-to determine if a point that would be returned should be skipped based on its 
+to determine if a point that would be returned should be skipped based on its
 index.
 """
 function knn(tree::NNTree{V}, points::Vector{T}, k::Int, sortres=false, skip::F=always_false) where {V, T <: AbstractVector, F<:Function}
@@ -27,7 +27,7 @@ function knn(tree::NNTree{V}, points::Vector{T}, k::Int, sortres=false, skip::F=
 end
 
 function knn_point!(tree::NNTree{V}, point::AbstractVector{T}, sortres, dist, idx, skip::F) where {V, T <: Number, F}
-    fill!(idx, -1)
+    fill!(idx, 1)
     fill!(dist, typemax(get_T(eltype(V))))
     _knn(tree, point, idx, dist, skip)
     sortres && heap_sort_inplace!(dist, idx)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,6 +31,7 @@ include("test_knn.jl")
 include("test_inrange.jl")
 include("test_monkey.jl")
 include("test_datafreetree.jl")
+include("test_specialfloats.jl")
 
 @testset "periodic euclidean" begin
     pred = PeriodicEuclidean([Inf, 2.5])


### PR DESCRIPTION
The patch merely modifies the algorithm to initialize the index list with `1` instead of `-1`. New tests are added that reproduce issues #78 and #125.

It's a bit of a decision what to do with NaNs, in my opinion it's best if we ensure indices are always valid, and a NaN distance is as good as Inf.