### PR TITLE
Add multithreading support

### DIFF
--- a/src/NearestNeighbors.jl
+++ b/src/NearestNeighbors.jl
@@ -7,7 +7,7 @@ using StaticArrays
 import Base.show
 
 export NNTree, BruteTree, KDTree, BallTree, DataFreeTree
-export knn, nn, inrange # TODOs? , allpairs, distmat, npairs
+export knn, nn, inrange, knn_threaded # TODOs? , allpairs, distmat, npairs
 export injectdata
 
 export Euclidean,

--- a/src/knn.jl
+++ b/src/knn.jl
@@ -18,31 +18,32 @@ function knn(tree::NNTree{V}, points::Vector{T}, k::Int, sortres=false, skip::F=
     check_input(tree, points)
     check_k(tree, k)
     n_points = length(points)
-     dists = [Vector{get_T(eltype(V))}(undef, k) for _ in 1:n_points]
-     idxs = [Vector{Int}(undef, k) for _ in 1:n_points]
+    dists = [Vector{get_T(eltype(V))}(undef, k) for _ in 1:n_points]
+    idxs = [Vector{Int}(undef, k) for _ in 1:n_points]
     for i in 1:n_points
         knn_point!(tree, points[i], sortres, dists[i], idxs[i], skip)
     end
     return idxs, dists
 end
 
+
 """
     knn(tree::NNTree, points, k [, sortres=false]) -> indices, distances
     nn(tree:NNTree, points) -> indices, distances
 
-Performs a lookup of the `k` nearest neigbours to the `points` from the data
-in the `tree`. If `sortres = true` the result is sorted such that the results are
-in the order of increasing distance to the point. `skip` is an optional predicate
-to determine if a point that would be returned should be skipped based on its 
-index.
+    Performs a lookup of the `k` nearest neigbours to the `points` from the data
+    in the `tree`. If `sortres = true` the result is sorted such that the results are
+    in the order of increasing distance to the point. `skip` is an optional predicate
+    to determine if a point that would be returned should be skipped based on its 
+    index.
 
-The keyword argument `n_tasks` determines how batches will be made from the inputs. The 
-batches are distributed on the available threads, determined by `Threads.nthreads()`. 
-See `https://docs.julialang.org/en/v1/manual/multi-threading` for help on how to make 
-Julia aware of available threads.
+    The keyword argument `n_tasks` determines how batches will be made from the inputs. The 
+    batches are distributed on the available threads, determined by `Threads.nthreads()`. 
+    See `https://docs.julialang.org/en/v1/manual/multi-threading` for help on how to make 
+    Julia aware of available threads.
 
-Multithreading can significantly slow down other processes on your computer.
-To avoid multithreading, set `n_tasks=1`
+    Multithreading can significantly slow down other processes on your computer.
+    To avoid multithreading, set `n_tasks=1`
 """
 function knn_threaded(tree::NNTree{V}, points::Vector{T}, k::Int, sortres=false, skip::F=always_false; n_tasks::Int = Threads.nthreads()) where {V, T <: AbstractVector, F<:Function}
     check_input(tree, points)
@@ -50,12 +51,11 @@ function knn_threaded(tree::NNTree{V}, points::Vector{T}, k::Int, sortres=false,
     n_points = length(points)
     dists = [Vector{get_T(eltype(V))}(undef, k) for _ in 1:n_points]
     idxs = [Vector{Int}(undef, k) for _ in 1:n_points]
-
-    inds, batches = _batch(points)
-
-    Threads.@threads for i in 1:batches
-        for j in inds[i]
-        knn_point!(tree, batches[i][j], sortres, dists[j], idxs[j], skip)
+    idxs_batched = _batched_inds(points, n_tasks)
+    Threads.@threads for inds in idxs_batched
+        for i in inds
+            knn_point!(tree, points[i], sortres, dists[i], idxs[i], skip)
+        end
     end
     return idxs, dists
 end
@@ -90,6 +90,17 @@ function knn(tree::NNTree{V}, point::AbstractMatrix{T}, k::Int, sortres=false, s
         new_data = SVector{dim,T}[SVector{dim,T}(point[:, i]) for i in 1:npoints]
     end
     knn(tree, new_data, k, sortres, skip)
+end
+
+function knn_threaded(tree::NNTree{V}, point::AbstractMatrix{T}, k::Int, sortres=false, skip::F=always_false; n_tasks::Int = Threads.nthreads()) where {V, T <: Number, F<:Function}
+    dim = size(point, 1)
+    npoints = size(point, 2)
+    if isbitstype(T)
+        new_data = copy_svec(T, point, Val(dim))
+    else
+        new_data = SVector{dim,T}[SVector{dim,T}(point[:, i]) for i in 1:npoints]
+    end
+    knn_threaded(tree, new_data, k, sortres, skip; n_tasks)
 end
 
 nn(tree::NNTree{V}, points::AbstractVector{T}, skip::F=always_false) where {V, T <: Number,         F <: Function} = _nn(tree, points, skip) .|> first

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -95,3 +95,23 @@ end
 # Instead of ReinterpretArray wrapper, copy an array, interpreting it as a vector of SVectors
 copy_svec(::Type{T}, data, ::Val{dim}) where {T, dim} =
         [SVector{dim,T}(ntuple(i -> data[n+i], Val(dim))) for n in 0:dim:(length(data)-1)]
+
+
+"""
+    _batch(v::AbstractVector, n_batches::Int)
+
+Compute `n_batches` batches from the input vector `v`.
+The number of elements in each batch is not even if `length(v) ÷ n_batches != length(v) / n_batches`.
+Returns a tuple with (indices, batched_v)
+"""
+function _batch(v::AbstractVector, n_batches::Int)
+    divs, rems = divrem(length(v), n_batches)
+    batchlengths = fill(divs, n_batches)
+    batchlengths[end-rems+1:end] .+= 1
+    
+    cumsums = pushfirst!(cumsum(batchlengths), 0)
+    indices = [cumsums[i]+1:cumsums[i+1] for i in 1:n_batches]
+    batched_v = getindex.([v], indices)
+    
+    return (indices, batched_v)
+end

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -104,14 +104,13 @@ Compute `n_batches` batches from the input vector `v`.
 The number of elements in each batch is not even if `length(v) ÷ n_batches != length(v) / n_batches`.
 Returns a tuple with (indices, batched_v)
 """
-function _batch(v::AbstractVector, n_batches::Int)
+function _batched_inds(v::AbstractVector, n_batches::Int)
     divs, rems = divrem(length(v), n_batches)
     batchlengths = fill(divs, n_batches)
     batchlengths[end-rems+1:end] .+= 1
     
     cumsums = pushfirst!(cumsum(batchlengths), 0)
     indices = [cumsums[i]+1:cumsums[i+1] for i in 1:n_batches]
-    batched_v = getindex.([v], indices)
     
-    return (indices, batched_v)
+    return indices
 end


### PR DESCRIPTION
This PR has added a function `knn_threaded`. I am able to achieve several X speedup from multithreading, but a several X slowdown for small problems. This is an acceptable tradeoff IMO, and possibly some smart heuristic can be implemented to only multithread when beneficial.

An internal `_batch_inds` function accomplishes the batching for separating the task into as few partitions as possible, based on the following quote from the readme:
"It is generally better for performance to query once with a large number of points than to query multiple times with one point per query."

I have been using the following function for timing:
```
using NearestNeighbors, BenchmarkTools
function time_knn(n, tree=BruteTree, metric=Euclidean(), k=1)
    times_knn = @belapsed knn($tree(randn($n, $n), $metric), randn($n, $n), $k)
    times_knn_threaded = @belapsed knn_threaded($tree(randn($n, $n), $metric), randn($n, $n), $k)

    speedup = times_knn / times_knn_threaded
    return speedup
end
```

which on my computer
```
julia> versioninfo()
Julia Version 1.7.1
Commit ac5cc99908 (2021-12-22 19:35 UTC)
Platform Info:
  OS: Windows (x86_64-w64-mingw32)
  CPU: Intel(R) Core(TM) i5-8265U CPU @ 1.60GHz
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-12.0.1 (ORCJIT, skylake)
```
with 4 physical and 8 logical cores, gives the following results:
```
julia> time_knn.([5, 20, 50, 200, 500, 1000])
6-element Vector{Float64}:
 0.1949891067538126
 0.3305439330543933
 1.9000000000000001
 2.6507951356407857
 2.79413549390029
 3.0004697251425743
```

This PR probably requires some cleaning, especially in determining a good API and possibly heuristics for when to use multithreading. I do not think that there should be a separate knn_threaded function, but I implemented it like this for now for easy comparison. If it is confirmed to be overall faster, then I think it should be the default option.