### PR TITLE
add inrect() query

### DIFF
--- a/src/NearestNeighbors.jl
+++ b/src/NearestNeighbors.jl
@@ -7,7 +7,7 @@ using StaticArrays
 import Base.show
 
 export NNTree, BruteTree, KDTree, BallTree, DataFreeTree
-export knn, nn, inrange, inrangecount # TODOs? , allpairs, distmat, npairs
+export knn, nn, inrange, inrangecount, inrect # TODOs? , allpairs, distmat, npairs
 export injectdata
 
 export Euclidean,

--- a/src/brute_tree.jl
+++ b/src/brute_tree.jl
@@ -80,3 +80,10 @@ function inrange_kernel!(tree::BruteTree,
     end
     return count
 end
+
+
+function inrange_rect!(tree::BruteTree, a, b, idxs)
+    for (i, x) in enumerate(tree.data)
+        all(a .<= x .<= b) && push!(idxs, i)
+    end
+end

--- a/src/inrange.jl
+++ b/src/inrange.jl
@@ -82,3 +82,10 @@ function inrangecount(tree::NNTree{V}, point::AbstractMatrix{T}, radius::Number)
     end
     return inrangecount(tree, new_data, radius)
 end
+
+
+function inrect(tree::NNTree, a, b)
+    idx = Int[]
+    inrange_rect!(tree, a, b, idx)
+    return idx
+end

--- a/src/kd_tree.jl
+++ b/src/kd_tree.jl
@@ -272,3 +272,14 @@ function inrange_kernel!(tree::KDTree,
     count += inrange_kernel!(tree, far, point, r, idx_in_ball, new_min)
     return count
 end
+
+
+function inrange_rect!(tree::KDTree, a, b, idxs, index=1)
+    if isleaf(tree.tree_data.n_internal_nodes, index)
+        add_points_inrange_rect!(idxs, tree, index, a, b)
+    else
+        (; split_val, split_dim) = tree.nodes[index]
+        a[split_dim] <= split_val && inrange_rect!(tree, a, b, idxs,  getleft(index))
+        b[split_dim] >= split_val && inrange_rect!(tree, a, b, idxs, getright(index))
+    end
+end

--- a/src/tree_ops.jl
+++ b/src/tree_ops.jl
@@ -128,6 +128,13 @@ end
     return count
 end
 
+function add_points_inrange_rect!(idxs, tree, index, a, b)
+    for z in get_leaf_range(tree.tree_data, index)
+        idx = tree.reordered ? z : tree.indices[z]
+        all(a .<= tree.data[idx] .<= b) && push!(idxs, tree.indices[z])
+    end
+end
+
 # Add all points in this subtree since we have determined
 # they are all within the desired range
 function addall(tree::NNTree, index::Int, idx_in_ball::Union{Nothing, Vector{Int}})

--- a/test/test_inrange.jl
+++ b/test/test_inrange.jl
@@ -67,6 +67,15 @@
                 @test idxs == repeat([[1]], size(data, 2))
                 counts = inrangecount(one_point_tree, data, 1.0)
                 @test counts == repeat([1], size(data, 2))
+
+                if TreeType ∈ (BruteTree, KDTree)
+                    @test inrect(tree, [0.5, 0.5, 0.5], [1.5, 1.5, 1.5]) == [8]
+                    @test inrect(tree, [0, 0, 0], [0, 0, 1]) |> sort == [1, 2]
+                    @test inrect(tree, [0, 0, 0], [0, 0.3, 0.5]) |> sort == [1]
+                    @test inrect(tree, [-0.1, 0, 0], [1.1, 1, 0.5]) |> sort == [1, 3, 5, 7]
+                    @test inrect(empty_tree, [-5, -5, -5], [5, 5, 5]) == []
+                    @test inrect(one_point_tree, [-5, -5, -5], [5, 5, 5]) == [1]
+                end
             end
             data = [0.0 0.0 0.0 0.0 1.0 1.0 1.0 1.0;
                     0.0 0.0 1.0 1.0 0.0 0.0 1.0 1.0;

--- a/test/test_monkey.jl
+++ b/test/test_monkey.jl
@@ -61,6 +61,25 @@ import NearestNeighbors.MinkowskiMetric
                 end
             end
 
+            if TreeType ∈ (BruteTree, KDTree)
+                @testset "inrect monkey" begin
+                    for i in 1:30
+                        dim_data = rand(1:6)
+                        size_data = rand(20:250)
+                        data = rand(T, dim_data, size_data)
+                        tree = TreeType(data, metric; leafsize = rand(1:8))
+                        btree = BruteTree(data, metric)
+                        a = rand(dim_data) .- 0.2
+                        b = rand(dim_data) .+ 0.2
+
+                        idxs = inrect(tree, a, b) |> sort
+                        bidxs = inrect(btree, a, b)
+
+                        @test idxs == bidxs
+                    end
+                end
+            end
+
             @testset "coupled monkey" begin
                 for i in 1:50
                     dim_data = rand(1:5)


### PR DESCRIPTION
Commonly called "range search" (https://en.wikipedia.org/wiki/Range_searching), but NN.jl already has `inrange` that selects points within a circle - so I call the new function `inrect`.