### PR TITLE
Add generic constructor to `HyperSphere`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@
 benchmarks/*.jld
 benchmarks/*.md
 Manifest.toml
-
+.vscode

--- a/src/hyperspheres.jl
+++ b/src/hyperspheres.jl
@@ -6,6 +6,7 @@ struct HyperSphere{N,T <: AbstractFloat}
 end
 
 HyperSphere(center::SVector{N,T1}, r::T2) where {N, T1, T2} = HyperSphere(center, convert(T1, r))
+HyperSphere(center::AbstractVector{T}, r) where {T} = HyperSphere{length(center),T}(center, r)
 
 @inline function intersects(m::M,
                             s1::HyperSphere{N,T},


### PR DESCRIPTION
This PR adds a constructor to `HyperSphere` that accepts an `AbstractVector`.
This constructor is needed because of this function:
```julia
function _inrange(tree::BallTree{V},
                  point::AbstractVector,
                  radius::Number,
                  idx_in_ball::Union{Nothing, Vector{Int}}) where {V}
    ball = HyperSphere(convert(V, point), convert(eltype(V), radius))  # The "query ball"
    return inrange_kernel!(tree, 1, point, ball, idx_in_ball)  # Call the recursive range finder
end
```
The type parameter `V` of `BallTree` accepts any subtype of `AbstractVector`, but in the current code, `HyperSphere` does not have a constructor that accepts `AbstractVector`s.