### PR TITLE
use ArrayOfArrays for return value to reduce the number of allocated arrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,7 @@ uuid = "b8a86587-4115-5ab1-83bc-aa920d37bbce"
 version = "0.4.13"
 
 [deps]
+ArraysOfArrays = "65a8f2f4-9b39-5baf-92e2-a9cc46fdf018"
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
@@ -10,6 +11,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Distances = "0.9, 0.10"
 StaticArrays = "0.9, 0.10, 0.11, 0.12, 1.0"
 julia = "1.0"
+ArraysOfArrays = "0.6"
 
 [extras]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/NearestNeighbors.jl
+++ b/src/NearestNeighbors.jl
@@ -4,6 +4,7 @@ using Distances
 import Distances: Metric, result_type, eval_reduce, eval_end, eval_op, eval_start, evaluate, parameters
 
 using StaticArrays
+using ArraysOfArrays
 import Base.show
 
 export NNTree, BruteTree, KDTree, BallTree, DataFreeTree

--- a/src/inrange.jl
+++ b/src/inrange.jl
@@ -13,10 +13,13 @@ function inrange(tree::NNTree,
     check_input(tree, points)
     check_radius(radius)
 
-    idxs = [Vector{Int}() for _ in 1:length(points)]
+    idxs = VectorOfArrays{Int, 1}()
+    idx = Int[]
 
     for i in 1:length(points)
-        inrange_point!(tree, points[i], radius, sortres, idxs[i])
+        inrange_point!(tree, points[i], radius, sortres, idx)
+        push!(idxs, idx)
+        resize!(idx, 0)
     end
     return idxs
 end

--- a/src/knn.jl
+++ b/src/knn.jl
@@ -18,10 +18,15 @@ function knn(tree::NNTree{V}, points::Vector{T}, k::Int, sortres=false, skip::F=
     check_input(tree, points)
     check_k(tree, k)
     n_points = length(points)
-    dists = [Vector{get_T(eltype(V))}(undef, k) for _ in 1:n_points]
-    idxs = [Vector{Int}(undef, k) for _ in 1:n_points]
+    dists = VectorOfArrays{Float64, 1}()
+    idxs = VectorOfArrays{Int, 1}()
+    dist = zeros(Float64, k)
+    idx = zeros(Int, k)
+
     for i in 1:n_points
-        knn_point!(tree, points[i], sortres, dists[i], idxs[i], skip)
+        knn_point!(tree, points[i], sortres, dist, idx, skip)
+        push!(dists, dist)
+        push!(idxs, idx)
     end
     return idxs, dists
 end


### PR DESCRIPTION
A long standing gripe for me has been that indices and distances are returned as standard nested `Array`s. Typically, each inner array hold quite a small number of neighbors so  it means that we allocate a large number of small arrays.

Using ArrayOfArrays, these are stored contigously in one large flat array instead.

The difference in allocations can be readily seen:

```julia
julia> input = rand(3, 10^6);

julia> tree = KDTree(rand(3, 10^6));

julia> @time knn(tree, input, 5);
  1.538003 seconds (2.00 M allocations: 221.253 MiB, 10.03% gc time)

julia> @time knn(tree, input, 5);
  1.489310 seconds (98 allocations: 189.884 MiB, 0.29% gc time)
```