### PR TITLE
avoid copying inputs when doing a `knn` or `inrange` for a matrix input

### DIFF
--- a/src/NearestNeighbors.jl
+++ b/src/NearestNeighbors.jl
@@ -37,6 +37,13 @@ function check_input(::NNTree{V1}, point::AbstractVector{T}) where {V1, T <: Num
     end
 end
 
+function check_input(::NNTree{V1}, m::AbstractMatrix) where {V1}
+    if length(V1) != size(m, 1)
+        throw(ArgumentError(
+            "dimension of input points:$(size(m, 1)) and tree data:$(length(V1)) must agree"))
+    end
+end
+
 get_T(::Type{T}) where {T <: AbstractFloat} = T
 get_T(::T) where {T} = Float64
 

--- a/src/inrange.jl
+++ b/src/inrange.jl
@@ -42,15 +42,23 @@ function inrange(tree::NNTree{V}, point::AbstractVector{T}, radius::Number, sort
     return idx
 end
 
-function inrange(tree::NNTree{V}, point::AbstractMatrix{T}, radius::Number, sortres=false) where {V, T <: Number}
-    dim = size(point, 1)
-    npoints = size(point, 2)
-    if isbitstype(T)
-        new_data = copy_svec(T, point, Val(dim))
-    else
-        new_data = SVector{dim,T}[SVector{dim,T}(point[:, i]) for i in 1:npoints]
+function inrange(tree::NNTree{V}, points::AbstractMatrix{T}, radius::Number, sortres=false) where {V, T <: Number}
+    dim = size(points, 1)
+    inrange_matrix(tree, points, radius, Val(dim), sortres)
+end
+
+function inrange_matrix(tree::NNTree{V}, points::AbstractMatrix{T}, radius::Number, ::Val{dim}, sortres) where {V, T <: Number, dim}
+    # TODO: DRY with inrange for AbstractVector
+    check_input(tree, points)
+    check_radius(radius)
+    n_points = size(points, 2)
+    idxs = [Vector{Int}() for _ in 1:n_points]
+
+    for i in 1:n_points
+        point = SVector{dim,T}(ntuple(j -> points[j, i], Val(dim)))
+        inrange_point!(tree, point, radius, sortres, idxs[i])
     end
-    inrange(tree, new_data, radius, sortres)
+    return idxs
 end
 
 """


### PR DESCRIPTION
For some reason we did the conversion to static vectors "wholesale" for the whole input matrix instead of just doing it point by point.

```julia 
julia> using NearestNeighbors

julia> tree = KDTree(rand(3, 100));

julia> @time input = rand(3, 10^6);
  0.036092 seconds (2 allocations: 22.888 MiB, 89.04% gc time)

# Before
julia> @time knn(tree, input, 5);
  0.368772 seconds (2.00 M allocations: 221.253 MiB, 5.09% gc time)

# After
julia> @time knn(tree, input, 5);
  0.395747 seconds (2.00 M allocations: 198.365 MiB, 17.31% gc time)
```

We can see we save copying that 20 mb input.