### PR TITLE
some fixes for weighted metrics

### DIFF
--- a/src/NearestNeighbors.jl
+++ b/src/NearestNeighbors.jl
@@ -21,8 +21,9 @@ export Euclidean,
 
 abstract type NNTree{V <: AbstractVector,P <: Metric} end
 
-const MinkowskiMetric = Union{Euclidean,Chebyshev,Cityblock,Minkowski,WeightedEuclidean,WeightedCityblock,WeightedMinkowski}
-
+const NonweightedMinowskiMetric = Union{Euclidean,Chebyshev,Cityblock,Minkowski}
+const WeightedMinowskiMetric = Union{WeightedEuclidean,WeightedCityblock,WeightedMinkowski}
+const MinkowskiMetric = Union{NonweightedMinowskiMetric, WeightedMinowskiMetric}
 function check_input(::NNTree{V1}, ::AbstractVector{V2}) where {V1, V2 <: AbstractVector}
     if length(V1) != length(V2)
         throw(ArgumentError(

--- a/src/evaluation.jl
+++ b/src/evaluation.jl
@@ -3,8 +3,9 @@
 @inline eval_pow(::WeightedEuclidean, s) = abs2(s)
 @inline eval_pow(d::Minkowski, s) = abs(s)^d.p
 
-@inline eval_diff(::MinkowskiMetric, a, b) = a - b
-@inline eval_diff(::Chebyshev, ::Any, b) = b
+@inline eval_diff(::NonweightedMinowskiMetric, a, b, dim) = a - b
+@inline eval_diff(::Chebyshev, ::Any, b, dim) = b
+@inline eval_diff(m::WeightedMinowskiMetric, a, b, dim) = m.weights[dim] * (a-b)
 
 function Distances.evaluate(d::Distances.UnionMetrics, a::AbstractVector,
                             b::AbstractVector, do_end::Bool)

--- a/src/kd_tree.jl
+++ b/src/kd_tree.jl
@@ -205,7 +205,7 @@ function knn_kernel!(tree::KDTree{V},
 
     split_diff_pow = eval_pow(M, split_diff)
     ddiff_pow = eval_pow(M, ddiff)
-    diff_tot = eval_diff(M, split_diff_pow, ddiff_pow)
+    diff_tot = eval_diff(M, split_diff_pow, ddiff_pow, split_dim)
     new_min = eval_reduce(M, min_dist, diff_tot)
     if new_min < best_dists[1]
         knn_kernel!(tree, far, point, best_idxs, best_dists, new_min, hyper_rec_far, skip)
@@ -275,7 +275,7 @@ function inrange_kernel!(tree::KDTree,
     # Call further sub tree with the new min distance
     split_diff_pow = eval_pow(M, split_diff)
     ddiff_pow = eval_pow(M, ddiff)
-    diff_tot = eval_diff(M, split_diff_pow, ddiff_pow)
+    diff_tot = eval_diff(M, split_diff_pow, ddiff_pow, split_dim)
     new_min = eval_reduce(M, min_dist, diff_tot)
     count += inrange_kernel!(tree, far, point, r, idx_in_ball, hyper_rec_far, new_min)
     return count

--- a/test/test_knn.jl
+++ b/test/test_knn.jl
@@ -91,3 +91,14 @@ end
     @test nearest == [1, 3]
     @test distance ≈ [0.02239688629947563, 0.13440059522389006]
 end
+
+@testset "weighted" begin
+    m = WeightedEuclidean([1e-5, 1])
+    data = [
+        0 0 1
+        0 1 0.
+    ]
+    tree = KDTree(data, m, leafsize=1)
+    p = [1, 0.9]
+    @test nn(tree, p)[1] == 2
+end


### PR DESCRIPTION
Fixes https://github.com/KristofferC/NearestNeighbors.jl/issues/169. cc @aplavin

Looking at this code now (for the first time in many years) I am not really happy with how it looks. Ideally we should only use the functions provided by Distances.jl and not need any `eval_pow` and `eval_diff` stuff.