### PR TITLE
Fix tree construction for vectors without `StaticArrays.setindex`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NearestNeighbors"
 uuid = "b8a86587-4115-5ab1-83bc-aa920d37bbce"
-version = "0.4.14"
+version = "0.4.15"
 
 [deps]
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
@@ -14,7 +14,8 @@ julia = "1.6"
 [extras]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
+Tensors = "48a634ad-e948-5137-8d70-aa71f2a747f4"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["LinearAlgebra", "Mmap", "Test"]
+test = ["LinearAlgebra", "Mmap", "Tensors", "Test"]

--- a/src/kd_tree.jl
+++ b/src/kd_tree.jl
@@ -99,6 +99,13 @@ end
            reorderbuffer = reorderbuffer_points)
 end
 
+Base.@propagate_inbounds function setindex(s::StaticArray, v, i)
+    return StaticArrays.setindex(s, v, i)
+end
+Base.@propagate_inbounds function setindex(s::V, v, i) where {V <: AbstractArray}
+    return V(setindex(SVector{length(V)}(s), v, i))
+end
+
 function build_KDTree(index::Int,
                       data::AbstractVector{V},
                       data_reordered::Vector{V},

--- a/test/test_knn.jl
+++ b/test/test_knn.jl
@@ -102,3 +102,17 @@ end
     p = [1, 0.9]
     @test nn(tree, p)[1] == 2
 end
+
+import Tensors
+@testset "Tensors.Vec (no `StaticArrays.setindex` defined)" begin
+    vdata = [rand(Tensors.Vec{2}) for _ in 1:10]
+    sdata = SVector{2}.(vdata)
+    vpoints = [rand(Tensors.Vec{2}) for _ in 1:2]
+    spoints = SVector{2}.(vpoints)
+    for TreeType in trees_with_brute
+        vtree = TreeType(vdata)
+        stree = TreeType(sdata)
+        @test nn(vtree, vpoints) == nn(vtree, spoints) ==
+              nn(stree, vpoints) == nn(stree, spoints)
+    end
+end


### PR DESCRIPTION
In #166 the `HyperRectangle` struct was changed to use the same vector type as the input data for the mins and maxes, and to use `StaticArrays.setindex` for "mutation". Since this function is not implemented for all working input types (for example `Tensors.Vec`) there was an `MethodError` thrown. This patch adds `NearestNeighbors.setindex` which dispatches to `StaticArrays.setindex` for `<: StaticArray.StaticArray` and for other types casts to `SVector` and then back to the original type after mutating.