### PR TITLE
optimize some hypersphere checks for minkowski metrics

### DIFF
--- a/src/ball_tree.jl
+++ b/src/ball_tree.jl
@@ -196,7 +196,8 @@ function inrange_kernel!(tree::BallTree,
 
     # If the query ball in the bounding sphere for the current sub tree
     # do not intersect we can disrecard the whole subtree
-    if !intersects(tree.metric, sphere, query_ball)
+    dist, do_intersect = intersects(tree.metric, sphere, query_ball)
+    if !do_intersect
         return 0
     end
 
@@ -209,7 +210,7 @@ function inrange_kernel!(tree::BallTree,
 
     # The query ball encloses the sub tree bounding sphere. Add all points in the
     # sub tree without checking the distance function.
-    if encloses(tree.metric, sphere, query_ball)
+    if encloses_fast(dist, tree.metric, sphere, query_ball)
         count += addall(tree, index, idx_in_ball)
     else
         # Recursively call the left and right sub tree.

--- a/src/hyperspheres.jl
+++ b/src/hyperspheres.jl
@@ -11,13 +11,42 @@ HyperSphere(center::AbstractVector, r) = HyperSphere(SVector{length(center)}(cen
 @inline function intersects(m::Metric,
                             s1::HyperSphere{N},
                             s2::HyperSphere{N}) where {N}
-    evaluate(m, s1.center, s2.center) <= s1.r + s2.r
+    d = evaluate(m, s1.center, s2.center)
+    return d, d <= s1.r + s2.r
+end
+
+@inline function intersects(m::MinkowskiMetric,
+                            s1::HyperSphere{N},
+                            s2::HyperSphere{N}) where {N}
+    d = evaluate_maybe_end(m, s1.center, s2.center, false)
+    return d, d <= eval_pow(m, s1.r + s2.r)
 end
 
 @inline function encloses(m::Metric,
                           s1::HyperSphere{N},
                           s2::HyperSphere{N}) where {N}
     evaluate(m, s1.center, s2.center) + s1.r <= s2.r
+end
+
+
+@inline function encloses_fast(d, m::Metric,
+                          s1::HyperSphere{N},
+                          s2::HyperSphere{N}) where {N}
+     if s1.r > s2.r
+        return false
+    else
+        return d + s1.r <= s2.r
+    end
+end
+
+@inline function encloses_fast(d, m::MinkowskiMetric,
+                          s1::HyperSphere{N},
+                          s2::HyperSphere{N}) where {N}
+    if s1.r > s2.r
+        return false
+    else
+        return d <= eval_pow(m, s2.r - s1.r)
+    end
 end
 
 @inline function interpolate(::NormMetric,


### PR DESCRIPTION
We can:

- Avoid computing the distance in `encloses` an extra time when searching since we already computed it in `intersect` earlier.
- Avoid computing the distance in encloses if the second hyper sphere has a larger radius then the other (which means the first one cannot enclose the second one).
- Avoid computing the "end reduction" (like `sqrt`) for some metrics when checking intersections and enclosures by "squaring both sides".

Some kind of benchmark:

```
julia> x = BallTree(rand(3,10^5));

# master
julia> @time inrange(x, rand(3,10^5), 0.01);
  0.186999 seconds (133.77 k allocations: 11.731 MiB)

# PR
julia> @time inrange(x, rand(3,10^5), 0.01);
  0.155827 seconds (133.87 k allocations: 11.739 MiB)
```