### PR TITLE
avoid some square rooting to check distances

### DIFF
--- a/src/ball_tree.jl
+++ b/src/ball_tree.jl
@@ -203,7 +203,8 @@ function inrange_kernel!(tree::BallTree,
 
     # At a leaf node, check all points in the leaf node
     if isleaf(tree.tree_data.n_internal_nodes, index)
-        return add_points_inrange!(idx_in_ball, tree, index, point, query_ball.r, true)
+        r = tree.metric isa MinkowskiMetric ? eval_pow(tree.metric, query_ball.r) : query_ball.r
+        return add_points_inrange!(idx_in_ball, tree, index, point, r)
     end
 
     count = 0

--- a/src/kd_tree.jl
+++ b/src/kd_tree.jl
@@ -209,7 +209,7 @@ function _inrange(tree::KDTree,
                   radius::Number,
                   idx_in_ball::Union{Nothing, Vector{<:Integer}} = Int[])
     init_min = get_min_distance_no_end(tree.metric, tree.hyper_rec, point)
-    return inrange_kernel!(tree, 1, point, eval_op(tree.metric, radius, zero(init_min)), idx_in_ball,
+    return inrange_kernel!(tree, 1, point, eval_pow(tree.metric, radius), idx_in_ball,
             tree.hyper_rec, init_min)
 end
 
@@ -228,7 +228,7 @@ function inrange_kernel!(tree::KDTree,
 
     # At a leaf node. Go through all points in node and add those in range
     if isleaf(tree.tree_data.n_internal_nodes, index)
-        return add_points_inrange!(idx_in_ball, tree, index, point, r, false)
+        return add_points_inrange!(idx_in_ball, tree, index, point, r)
     end
 
     split_val = tree.split_vals[index]

--- a/src/tree_ops.jl
+++ b/src/tree_ops.jl
@@ -115,18 +115,26 @@ end
 # This will probably prevent SIMD and other optimizations so some care is needed
 # to evaluate if it is worth it.
 @inline function add_points_inrange!(idx_in_ball::Union{Nothing, AbstractVector{<:Integer}}, tree::NNTree,
-                                     index::Int, point::AbstractVector, r::Number, do_end::Bool)
+                                     index::Int, point::AbstractVector, r::Number)
     count = 0
     for z in get_leaf_range(tree.tree_data, index)
         idx = tree.reordered ? z : tree.indices[z]
-        dist_d = evaluate_maybe_end(tree.metric, tree.data[idx], point, do_end)
-        if dist_d <= r
+        if check_in_range(tree.metric, tree.data[idx], point, r)
             count += 1
             idx_in_ball !== nothing && push!(idx_in_ball, idx)
         end
     end
     return count
 end
+
+function check_in_range(metric::Metric, x1, x2, r)
+    evaluate(metric, x1, x2) <= r
+end
+
+function check_in_range(metric::MinkowskiMetric, x1, x2, r)
+    evaluate_maybe_end(metric, x1, x2, false) <= r
+end
+
 
 # Add all points in this subtree since we have determined
 # they are all within the desired range


### PR DESCRIPTION
```
 using Revise, StableRNGs
 using NearestNeighbors
 data = rand(StableRNG(1), 3, 10^4);
 x = BallTree(data);
 v = rand(StableRNG(1), 3);
 using GFlops
 @count_ops inrange(x, v, 0.01)
```

Master:

```
Flop Counter: 1491 flop
┌──────┬─────────┐
│      │ Float64 │
├──────┼─────────┤
│  add │     438 │
│  sub │     468 │
│  mul │     555 │
│ sqrt │      30 │
└──────┴─────────┘
```

PR:

```
Flop Counter: 1491 flop
┌─────┬─────────┐
│     │ Float64 │
├─────┼─────────┤
│ add │     438 │
│ sub │     468 │
│ mul │     558 │
└─────┴─────────┘
```

No more square roots 🎉.

