### PR TITLE
use the maximum distance to hyper rectangle to add all points in the subtree for `inrange` calculations

### DIFF
--- a/src/hyperrectangles.jl
+++ b/src/hyperrectangles.jl
@@ -53,3 +53,23 @@ get_min_distance_no_end(m, rec, point) =
     diff_tot = eval_diff(M, split_diff_pow, ddiff_pow, split_dim)
     return old_min + diff_tot
 end
+
+# Compute per-dimension contributions for max distance
+function get_max_distance_contributions(m::Metric, rec::HyperRectangle{V}, point::AbstractVector{T}) where {V,T}
+    p = Distances.parameters(m)
+    return V(
+        @inbounds begin
+                v = distance_function_max(point[dim], rec.maxes[dim], rec.mins[dim])
+                p === nothing ? eval_op(m, v, zero(T)) : eval_op(m, v, zero(T), p[dim])
+            end for dim in eachindex(point)
+    )
+end
+
+# Compute single dimension contribution for max distance
+function get_max_distance_contribution_single(m::Metric, point_dim, min_bound::T, max_bound::T, dim::Integer) where {T}
+    v = distance_function_max(point_dim, max_bound, min_bound)
+    p = Distances.parameters(m)
+    return p === nothing ? eval_op(m, v, zero(T)) : eval_op(m, v, zero(T), p[dim])
+end
+
+

--- a/src/kd_tree.jl
+++ b/src/kd_tree.jl
@@ -217,16 +217,22 @@ function inrange_kernel!(tree::KDTree,
         return 0
     end
 
+    M = tree.metric
+
     # At a leaf node. Go through all points in node and add those in range
     if isleaf(tree.tree_data.n_internal_nodes, index)
         return add_points_inrange!(idx_in_ball, tree, index, point, r)
+    end
+
+    max_dist = get_max_distance_no_end(M, hyper_rec, point)
+    if max_dist < r
+        return addall(tree, index, idx_in_ball)
     end
 
     split_val = tree.split_vals[index]
     split_dim = tree.split_dims[index]
     p_dim = point[split_dim]
     split_diff = p_dim - split_val
-    M = tree.metric
 
     count = 0
 
@@ -243,11 +249,6 @@ function inrange_kernel!(tree::KDTree,
     end
     # Call closer sub tree
     count += inrange_kernel!(tree, close, point, r, idx_in_ball, hyper_rec_close, min_dist)
-
-    # TODO: We could potentially also keep track of the max distance
-    # between the point and the hyper rectangle and add the whole sub tree
-    # in case of the max distance being <= r similarly to the BallTree inrange method.
-    # It would be interesting to benchmark this on some different data sets.
 
     # Call further sub tree with the new min distance
     if M isa Chebyshev

--- a/src/kd_tree.jl
+++ b/src/kd_tree.jl
@@ -195,38 +195,45 @@ function knn_kernel!(tree::KDTree{V},
     return
 end
 
-function _inrange(tree::KDTree,
-                  point::AbstractVector,
-                  radius::Number,
-                  idx_in_ball::Union{Nothing, Vector{<:Integer}} = Int[])
+function _inrange(
+        tree::KDTree,
+        point::AbstractVector,
+        radius::Number,
+        idx_in_ball::Union{Nothing, Vector{<:Integer}} = Int[]
+    )
     init_min = get_min_distance_no_end(tree.metric, tree.hyper_rec, point)
-    return inrange_kernel!(tree, 1, point, eval_pow(tree.metric, radius), idx_in_ball,
-            tree.hyper_rec, init_min)
+    init_max_contribs = get_max_distance_contributions(tree.metric, tree.hyper_rec, point)
+    init_max = tree.metric isa Chebyshev ? maximum(init_max_contribs) : sum(init_max_contribs)
+    return inrange_kernel!(
+        tree, 1, point, eval_pow(tree.metric, radius), idx_in_ball,
+        tree.hyper_rec, init_min, init_max_contribs, init_max
+    )
 end
 
 # Explicitly check the distance between leaf node and point while traversing
-function inrange_kernel!(tree::KDTree,
-                         index::Int,
-                         point::AbstractVector,
-                         r::Number,
-                         idx_in_ball::Union{Nothing, Vector{<:Integer}},
-                         hyper_rec::HyperRectangle,
-                         min_dist)
+function inrange_kernel!(
+        tree::KDTree,
+        index::Int,
+        point::AbstractVector,
+        r::Number,
+        idx_in_ball::Union{Nothing, Vector{<:Integer}},
+        hyper_rec::HyperRectangle,
+        min_dist,
+        max_dist_contribs::SVector,
+        max_dist
+    )
     # Point is outside hyper rectangle, skip the whole sub tree
     if min_dist > r
         return 0
     end
 
-    M = tree.metric
+    if max_dist < r
+        return addall(tree, index, idx_in_ball)
+    end
 
     # At a leaf node. Go through all points in node and add those in range
     if isleaf(tree.tree_data.n_internal_nodes, index)
         return add_points_inrange!(idx_in_ball, tree, index, point, r)
-    end
-
-    max_dist = get_max_distance_no_end(M, hyper_rec, point)
-    if max_dist < r
-        return addall(tree, index, idx_in_ball)
     end
 
     split_val = tree.split_vals[index]
@@ -247,16 +254,36 @@ function inrange_kernel!(tree::KDTree,
         hyper_rec_far = HyperRectangle(@inbounds(setindex(hyper_rec.mins, split_val, split_dim)), hyper_rec.maxes)
         hyper_rec_close = HyperRectangle(hyper_rec.mins, @inbounds setindex(hyper_rec.maxes, split_val, split_dim))
     end
-    # Call closer sub tree
-    count += inrange_kernel!(tree, close, point, r, idx_in_ball, hyper_rec_close, min_dist)
-
-    # Call further sub tree with the new min distance
-    if M isa Chebyshev
-        new_min = get_min_distance_no_end(M, hyper_rec_far, point)
+    # Compute contributions for both close and far subtrees
+    M = tree.metric
+    old_contrib = max_dist_contribs[split_dim]
+    if split_diff > 0
+        # Point is to the right
+        # Close subtree: split_val as new min, far subtree: split_val as new max  
+        new_contrib_close = get_max_distance_contribution_single(M, point[split_dim], split_val, hyper_rec.maxes[split_dim], split_dim)
+        new_contrib_far = get_max_distance_contribution_single(M, point[split_dim], hyper_rec.mins[split_dim], split_val, split_dim)
     else
-        new_min = update_new_min(M, min_dist, hyper_rec, p_dim, split_dim, split_val)
+        # Point is to the left
+        # Close subtree: split_val as new max, far subtree: split_val as new min
+        new_contrib_close = get_max_distance_contribution_single(M, point[split_dim], hyper_rec.mins[split_dim], split_val, split_dim)
+        new_contrib_far = get_max_distance_contribution_single(M, point[split_dim], split_val, hyper_rec.maxes[split_dim], split_dim)
     end
 
-    count += inrange_kernel!(tree, far, point, r, idx_in_ball, hyper_rec_far, new_min)
+    # Update contributions and distances for close subtree
+    new_max_contribs_close = setindex(max_dist_contribs, new_contrib_close, split_dim)
+    new_max_dist_close = M isa Chebyshev ? maximum(new_max_contribs_close) : max_dist - old_contrib + new_contrib_close
+
+    # Call closer sub tree
+    count += inrange_kernel!(tree, close, point, r, idx_in_ball, hyper_rec_close, min_dist, new_max_contribs_close, new_max_dist_close)
+
+    # Compute new min distance for far subtree
+    new_min = M isa Chebyshev ? get_min_distance_no_end(M, hyper_rec_far, point) : update_new_min(M, min_dist, hyper_rec, p_dim, split_dim, split_val)
+
+    # Update contributions and distances for far subtree
+    new_max_contribs_far = setindex(max_dist_contribs, new_contrib_far, split_dim)
+    new_max_dist_far = M isa Chebyshev ? maximum(new_max_contribs_far) : max_dist - old_contrib + new_contrib_far
+
+    # Call further sub tree
+    count += inrange_kernel!(tree, far, point, r, idx_in_ball, hyper_rec_far, new_min, new_max_contribs_far, new_max_dist_far)
     return count
 end


### PR DESCRIPTION
All the tests I have done shows a reduction in flops and improved performance with this. As the radius increase this becomes more and more beneficial.

For example with

```julia
using StaticArrays, NearestNeighbors, StableRNGs, BenchmarkTools

# For uniform distribution in unit hypercube [0,1]^d,
# the expected fraction of points within radius r is approximately:
# Volume of hypersphere with radius r = π^(d/2) * r^d / Γ(d/2 + 1)
# Solving for r: r = (target_fraction * Γ(d/2 + 1) / π^(d/2))^(1/d)

function compute_radius_for_fraction(dim::Int, target_fraction::Float64)
    # Manual computation of Γ(dim/2 + 1) for small integer dimensions
    if dim % 2 == 0
        # Even dimension: Γ(n+1) = n! where n = dim/2
        n = dim ÷ 2
        gamma_term = factorial(n)
    else
        # Odd dimension: Γ(n+0.5) = (2n)! * √π / (4^n * n!) where n = (dim-1)/2
        n = (dim - 1) ÷ 2
        gamma_term = factorial(2*n) * sqrt(π) / (4^n * factorial(n))
    end

    pi_term = π^(dim/2)

    r = (target_fraction * gamma_term / pi_term)^(1/dim)
    return r
end

for dim in (2,3,5)
    data = rand(StableRNG(1), dim, 10^6);
    for target_fraction = [0.001, 0.01, 0.05, 0.1, 0.2]
        r = compute_radius_for_fraction(dim, target_fraction)
        point = rand(StableRNG(2), dim);
        x = KDTree(data)
        l = @btime inrange($x, $point, $r)
    end
end
```

I get

master
```
  3.614 μs (8 allocations: 21.83 KiB)
  20.957 μs (12 allocations: 121.91 KiB)
  86.362 μs (16 allocations: 812.55 KiB)
  141.991 μs (16 allocations: 812.55 KiB)
  247.547 μs (18 allocations: 1.83 MiB)
  3.082 μs (6 allocations: 7.54 KiB)
  18.203 μs (12 allocations: 121.91 KiB)
  72.174 μs (14 allocations: 326.45 KiB)
  137.667 μs (16 allocations: 812.55 KiB)
  240.863 μs (16 allocations: 812.55 KiB)
  8.324 μs (6 allocations: 7.54 KiB)
  32.429 μs (10 allocations: 53.87 KiB)
  111.277 μs (12 allocations: 121.91 KiB)
  193.624 μs (14 allocations: 326.45 KiB)
  329.769 μs (14 allocations: 326.45 KiB)
```

PR
```
  2.792 μs (8 allocations: 21.83 KiB)
  12.316 μs (12 allocations: 121.91 KiB)
  46.090 μs (16 allocations: 812.55 KiB)
  70.028 μs (16 allocations: 812.55 KiB)
  127.682 μs (18 allocations: 1.83 MiB)
  3.096 μs (6 allocations: 7.54 KiB)
  15.067 μs (12 allocations: 121.91 KiB)
  53.540 μs (14 allocations: 326.45 KiB)
  99.493 μs (16 allocations: 812.55 KiB)
  163.672 μs (16 allocations: 812.55 KiB)
  8.093 μs (6 allocations: 7.54 KiB)
  35.132 μs (10 allocations: 53.87 KiB)
  120.850 μs (12 allocations: 121.91 KiB)
  209.334 μs (14 allocations: 326.45 KiB)
  345.637 μs (14 allocations: 326.45 KiB)
```