### PR TITLE
Update Julia version from 1.6 to 1.7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ CellListMap = "0.9.14"
 Distances = "0.10.12"
 StableRNGs = "1.0.4"
 StaticArrays = "0.9, 0.10, 0.11, 0.12, 1.0"
-julia = "1.6"
+julia = "1.7"
 
 [extras]
 CellListMap = "69e1c6dd-3888-40e6-b3c8-31ac5f578864"


### PR DESCRIPTION
It looks like 0.4.23 added the use of the `Returns` function in various locations. Support for `Returns` was added in Julia 1.7, so this change bumps the compat requirements to 1.7 so that users on older versions of julia do not accidentally pull in 0.4.23.