### PR TITLE
force specialize on skip function in a few places

### DIFF
--- a/src/ball_tree.jl
+++ b/src/ball_tree.jl
@@ -256,7 +256,7 @@ function inrange_kernel!(tree::BallTree,
 end
 
 # Add every pair from two subtrees without distance checks once their bounds are fully inside the radius
-function _addall_balltree_self!(results::Vector{NTuple{2,Int}}, tree::BallTree, idx::Int, other_idx::Int, skip)
+function _addall_balltree_self!(results::Vector{NTuple{2,Int}}, tree::BallTree, idx::Int, other_idx::Int, skip::F) where {F}
     leaf_here = isleaf(tree.tree_data.n_internal_nodes, idx)
     leaf_other = isleaf(tree.tree_data.n_internal_nodes, other_idx)
     if leaf_here

--- a/src/kd_tree.jl
+++ b/src/kd_tree.jl
@@ -455,7 +455,7 @@ function _add_kdtree_self_leaf_pairs!(results, tree::KDTree, leaf_idx::Int, othe
 end
 
 # Add all pairs from two subtrees without distance checks once both rectangles are fully inside the radius
-function _addall_kdtree_self!(results, tree::KDTree, idx::Int, other_idx::Int, skip)
+function _addall_kdtree_self!(results, tree::KDTree, idx::Int, other_idx::Int, skip::F) where {F}
     leaf_here = isleaf(tree.tree_data.n_internal_nodes, idx)
     leaf_other = isleaf(tree.tree_data.n_internal_nodes, other_idx)
     if leaf_here


### PR DESCRIPTION
Test:

```julia
using BenchmarkTools, NearestNeighbors
using StableRNGs

kdtree = KDTree(rand(StableRNG(1), 3, 10^5)); balltree = BallTree(rand(StableRNG(1), 3, 10^5))

inrange_pairs(kdtree, 0.1, true)
inrange_pairs(balltree, 0.1, true)

@time p1 = inrange_pairs(kdtree, 0.1, true)
@time p2 = inrange_pairs(balltree, 0.1, true)
@assert p1 == p2
``` 

Before:

```
  1.424783 seconds (1.32 k allocations: 1.035 GiB, 6.75% gc time)
  1.432281 seconds (12.19 k allocations: 1.036 GiB, 6.21% gc time)
```

After:

```
 1.485357 seconds (104 allocations: 1.035 GiB, 6.57% gc time)
 1.496546 seconds (57 allocations: 1.035 GiB, 6.47% gc time)
```