### PR TITLE
Fix more unit errors

### DIFF
--- a/src/kd_tree.jl
+++ b/src/kd_tree.jl
@@ -195,7 +195,7 @@ function knn_kernel!(tree::KDTree{V},
     left_idx = getleft(index)
     right_idx = getright(index)
     # Point is to the right of the split value
-    if split_diff > 0
+    if split_diff > zero(split_diff)
         close = right_idx
         far = left_idx
         hyper_rec_far = left_region
@@ -274,7 +274,7 @@ function inrange_kernel!(
     left_region, right_region = split_hyperrectangle(hyper_rec, split_dim, split_val)
     left_idx = getleft(index)
     right_idx = getright(index)
-    if split_diff > 0 # Point is to the right of the split value
+    if split_diff > zero(split_diff) # Point is to the right of the split value
         close = right_idx
         far = left_idx
         hyper_rec_far = left_region
@@ -288,7 +288,7 @@ function inrange_kernel!(
     # Compute contributions for both close and far subtrees
     M = tree.metric
     old_contrib = max_dist_contribs[split_dim]
-    if split_diff > 0
+    if split_diff > zero(split_diff)
         # Point is to the right
         # Close subtree: split_val as new min, far subtree: split_val as new max
         new_contrib_close = get_max_distance_contribution_single(M, point[split_dim], split_val, hyper_rec.maxes[split_dim], split_dim)

--- a/test/test_unitful.jl
+++ b/test/test_unitful.jl
@@ -13,7 +13,10 @@ using Unitful
 
     # Data with units
     m = u"m"
-    data_unitful = [SVector(1.0m, 2.0m, 3.0m), SVector(2.0m, 3.0m, 4.0m), SVector(10.0m, 10.0m, 10.0m)]
+    data_unitful = mapreduce(vcat, range(0.0m, 0.5m; length = 20)) do d
+        [SVector(d, d, d) + v
+        for v in [SVector(1.0m, 2.0m, 3.0m), SVector(2.0m, 3.0m, 4.0m), SVector(10.0m, 10.0m, 10.0m)]]
+    end
     query_unitful = [1.0m, 2.0m, 3.0m]
     bounds_min_unitful = [0.0m, 0.0m, 0.0m]
     bounds_max_unitful = [20.0m, 20.0m, 20.0m]


### PR DESCRIPTION
I found some more places that didn't handle unitful data correctly. The previous test was too simple and didn't catch that. I suspect that all tree nodes became leaves and thus the branch with the erroneous lines was not tested. I tried to fix that by using more complex test data. It looks a bit awkward so maybe we can come up with a better idea.