### PR TITLE
KDTree derive zero from diff-type

### DIFF
--- a/src/kd_tree.jl
+++ b/src/kd_tree.jl
@@ -195,7 +195,7 @@ function knn_kernel!(tree::KDTree{V},
     left_idx = getleft(index)
     right_idx = getright(index)
     # Point is to the right of the split value
-    if split_diff > 0
+    if split_diff > zero(split_val)
         close = right_idx
         far = left_idx
         hyper_rec_far = left_region
@@ -274,7 +274,7 @@ function inrange_kernel!(
     left_region, right_region = split_hyperrectangle(hyper_rec, split_dim, split_val)
     left_idx = getleft(index)
     right_idx = getright(index)
-    if split_diff > 0 # Point is to the right of the split value
+    if split_diff > zero(split_diff) # Point is to the right of the split value
         close = right_idx
         far = left_idx
         hyper_rec_far = left_region
@@ -288,7 +288,7 @@ function inrange_kernel!(
     # Compute contributions for both close and far subtrees
     M = tree.metric
     old_contrib = max_dist_contribs[split_dim]
-    if split_diff > 0
+    if split_diff > zero(split_diff)
         # Point is to the right
         # Close subtree: split_val as new min, far subtree: split_val as new max
         new_contrib_close = get_max_distance_contribution_single(M, point[split_dim], split_val, hyper_rec.maxes[split_dim], split_dim)


### PR DESCRIPTION
Hello, I stumbled over an issue with KDTrees and unitful data. A MWE can be seen here:

```julia
using NearestNeighbors, NearestNeighbors.StaticArrays, Unitful
data = [SVector{3}(rand(3)u"m") for i in 1:100]

# Create trees
kdtree = KDTree(data; leafsize = 25)
nn(kdtree, first(data))
```
To fix this, I changed the zero in the split-value comparision to be derived fomr the `split_diff`. Another alternative could be to extend the parametric signature up to `T` of the `KDTree`.

I did not add any tests yet, let me know if I should add an example with Unitful or another type.

Also the constructor does not seem to work with just a Unitful vector/matrix. In my use case I directly created a vector of SVectors as I did in the MWE and bypassed that issue